### PR TITLE
PR requesting dispatch forward instead of redirect

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/AccessServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/AccessServlet.java
@@ -26,11 +26,11 @@ package com.peregrine.admin.servlets;
  */
 
 import com.peregrine.commons.servlets.AbstractBaseServlet;
+import org.apache.sling.api.request.RequestDispatcherOptions;
 import org.osgi.service.component.annotations.Component;
-
 import javax.servlet.Servlet;
+import javax.servlet.ServletException;
 import java.io.IOException;
-
 import static com.peregrine.admin.servlets.AdminPaths.RESOURCE_TYPE_ACCESS;
 import static com.peregrine.commons.util.PerUtil.EQUALS;
 import static com.peregrine.commons.util.PerUtil.GET;
@@ -60,8 +60,10 @@ import static org.osgi.framework.Constants.SERVICE_VENDOR;
 public class AccessServlet extends AbstractBaseServlet {
 
     @Override
-    protected Response handleRequest(Request request) throws IOException {
-        return new RedirectResponse("/system/sling/info.sessionInfo.json");
+    protected Response handleRequest(Request request) throws IOException, ServletException {
+        RequestDispatcherOptions rdOtions = new RequestDispatcherOptions();
+        request.getRequest().getRequestDispatcher("/system/sling/info.sessionInfo.json", rdOtions).forward(request.getRequest(), request.getResponse());
+        return null;
     }
 }
 

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/AccessServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/AccessServlet.java
@@ -62,8 +62,7 @@ public class AccessServlet extends AbstractBaseServlet {
     @Override
     protected Response handleRequest(Request request) throws IOException, ServletException {
         RequestDispatcherOptions rdOtions = new RequestDispatcherOptions();
-        request.getRequest().getRequestDispatcher("/system/sling/info.sessionInfo.json", rdOtions).forward(request.getRequest(), request.getResponse());
-        return null;
+        return new ForwardResponse("/system/sling/info.sessionInfo.json", rdOtions);
     }
 }
 

--- a/platform/commons/src/main/java/com/peregrine/commons/servlets/AbstractBaseServlet.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/servlets/AbstractBaseServlet.java
@@ -37,7 +37,7 @@ import static com.peregrine.commons.util.PerConstants.TEXT_MIME_TYPE;
  * Base Class for Peregrine Servlets
  *
  * This class requests a handleRequest() method to the
- * sub classes with one Request and one Reponse object.
+ * sub classes with one Request and one Response object.
  * It will then handle the response and return it back to the
  * caller in a consistent manner including errors.
  *

--- a/platform/commons/src/main/java/com/peregrine/commons/servlets/AbstractBaseServlet.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/servlets/AbstractBaseServlet.java
@@ -540,6 +540,7 @@ public abstract class AbstractBaseServlet
     {
         private Resource resource;
         private RequestDispatcherOptions requestDispatcherOptions;
+        private String path;
 
         /**
          * Creates a Forward Response
@@ -556,9 +557,25 @@ public abstract class AbstractBaseServlet
             this.requestDispatcherOptions = requestDispatcherOptions;
         }
 
+        /**
+         * Creates a Forward Response by path in case one needs to forward to a servlet path
+         * servlet @param path to be forwarded to
+         * @param requestDispatcherOptions Request Dispatcher Options
+         * @throws IllegalArgumentException If the resource to be forwarded to is null
+         */
+        public ForwardResponse(String path, RequestDispatcherOptions requestDispatcherOptions){
+            super(DIRECT);
+            this.path = path;
+            this.requestDispatcherOptions = requestDispatcherOptions;
+        }
+
         @Override
         public void handleDirect(SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException {
-            request.getRequestDispatcher(resource, requestDispatcherOptions).forward(request, response);
+            if(resource != null){
+                request.getRequestDispatcher(resource, requestDispatcherOptions).forward(request, response);
+            } else if (path != null){
+                request.getRequestDispatcher(path, requestDispatcherOptions).forward(request, response);
+            }
         }
 
         @Override


### PR DESCRIPTION
I'm suggesting that you change from 302 redirect to a requestdispatcher forward call to avoid redirecting to http when behind the elb https proxy. 