### PR TITLE
rollback materialize-css

### DIFF
--- a/admin-base/ui.apps/package.json
+++ b/admin-base/ui.apps/package.json
@@ -21,7 +21,7 @@
     "jsdoc-vue": "^1.0.0",
     "marked": "^0.6.0",
     "material-design-icons": "^3.0.1",
-    "materialize-css": "^1.0.0",
+    "materialize-css": "^0.100.2",
     "quill": "^1.3.6",
     "request": "^2.88.0",
     "rollup": "^1.1.2",


### PR DESCRIPTION
materialize-css update caused broken collapsible elements. Make sure to remove node_modules folder and re install