### PR TITLE
Fix for #13, build issue caused by update to vue-runtime-helpers. rol…

### DIFF
--- a/buildscripts/buildvue.js
+++ b/buildscripts/buildvue.js
@@ -5,6 +5,7 @@ const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
 const buble     = require('rollup-plugin-buble')
+const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
 
 console.log('=== building vue files ========================================')
@@ -56,7 +57,8 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble()
+      buble(),
+      commonjs()
     ]
   }).then( function(bundle) {
 

--- a/buildscripts/package.json
+++ b/buildscripts/package.json
@@ -15,6 +15,7 @@
     "request": "^2.88.0",
     "rollup": "^1.1.2",
     "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-vue": "^4.6.1",
     "vue": "^2.5.22",
     "vue-template-compiler": "^2.5.22",

--- a/samples/blog/ui.apps/src/main/content/buildscripts/buildvue.js
+++ b/samples/blog/ui.apps/src/main/content/buildscripts/buildvue.js
@@ -5,6 +5,7 @@ const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
 const buble     = require('rollup-plugin-buble')
+const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
 
 console.log('=== building vue files ========================================')
@@ -54,7 +55,8 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble()
+      buble(),
+      commonjs()
     ]
   }).then( function(bundle) {
 

--- a/samples/experiences/ui.apps/src/main/content/buildscripts/buildvue.js
+++ b/samples/experiences/ui.apps/src/main/content/buildscripts/buildvue.js
@@ -5,6 +5,7 @@ const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
 const buble     = require('rollup-plugin-buble')
+const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
 
 console.log('=== building vue files ========================================')
@@ -54,7 +55,8 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble()
+      buble(),
+      commonjs()
     ]
   }).then( function(bundle) {
 

--- a/samples/uswds/ui.apps/src/main/content/buildscripts/buildvue.js
+++ b/samples/uswds/ui.apps/src/main/content/buildscripts/buildvue.js
@@ -5,6 +5,7 @@ const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
 const buble     = require('rollup-plugin-buble')
+const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
 
 console.log('=== building vue files ========================================')
@@ -54,7 +55,8 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble()
+      buble(),
+      commonjs()
     ]
   }).then( function(bundle) {
 

--- a/themes/themeclean/ui.apps/package.json
+++ b/themes/themeclean/ui.apps/package.json
@@ -14,6 +14,7 @@
     "fs-extra": "^7.0.1",
     "rollup": "^1.1.2",
     "rollup-plugin-buble": "^0.19.6",
+    "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-vue": "^4.6.1",
     "vue": "^2.5.22",
     "vue-template-compiler": "^2.5.22"

--- a/themes/themeclean/ui.apps/src/main/content/buildscripts/buildvue.js
+++ b/themes/themeclean/ui.apps/src/main/content/buildscripts/buildvue.js
@@ -5,6 +5,7 @@ const rollup    = require( 'rollup' )
 const path      = require('path')
 const vue       = require('rollup-plugin-vue')
 const buble     = require('rollup-plugin-buble')
+const commonjs  = require('rollup-plugin-commonjs')
 const camelcase = require('camelcase')
 
 console.log('=== building vue files ========================================')
@@ -54,7 +55,8 @@ function compileComponent(file){
         compileTemplate: true,
         css: `${distBasePath}/css/${nameCamelCase}.css`
       }),
-      buble()
+      buble(),
+      commonjs()
     ]
   }).then( function(bundle) {
 


### PR DESCRIPTION
This turned out to be caused by an update to rollup-plugin-vue. As per this commit:

[vuejs/rollup-plugin-vue@fd3dfb9](https://github.com/vuejs/rollup-plugin-vue/commit/fd3dfb9a4440b13b220fb2dc535506274280fa0c)

rollup-plugin-commonjs is now required to be imported when we are using rollup-plugin-vue.

The root cause here was our upgrade of vue-runtime-helpers to 1.0.0