### PR TITLE
Issues/36, fix for object wizard

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createobjectwizard/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createobjectwizard/template.vue
@@ -48,7 +48,7 @@
             <vue-form-generator :model="formmodel"
                                 :schema="objectSchema"
                                 :options="formOptions"
-                                ref="nameTab">
+                                ref="verifyTab">
 
             </vue-form-generator>
         </tab-content>


### PR DESCRIPTION
Duplicate use of ref attribute value led to step three of object wizard being validated during step two validation, which prevented users from proceeding in the wizard. 

Fix for https://github.com/headwirecom/peregrine-cms/issues/36