### PR TITLE
Fix item titles when created site from template

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
@@ -849,10 +849,8 @@ public class AdminResourceHandlerService
                     }
                 }
                 Resource childTarget = source.getResourceResolver().create(target, child.getName(), newProperties);
-                if(depth > 0) {
-                    toName = (String) newProperties.get(JCR_TITLE);
-                }
-                updateTitle(childTarget, toName);
+                updateTitle(childTarget, (((depth > 0) && (newProperties.get(JCR_TITLE) != null)) ?  (String) newProperties.get(JCR_TITLE) : toName));
+
                 logger.trace("Child Target Created: '{}'", childTarget == null ? "null" : childTarget.getPath());
                 // Copy grandchildren
                 if(deep) {


### PR DESCRIPTION
Fix for #42. When calling copyResources to copy a site from a template, only use the new name for the top-level resource, to prevent every object from having the same name.

