### PR TITLE
Issues/51

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -127,7 +127,7 @@ public class NodesServlet extends AbstractBaseServlet {
                     json.writeObject();
                     json.writeAttribute(NAME,child.getName());
                     json.writeAttribute(PATH,child.getPath());
-                    writeProperties(child, json, true);
+                    writeProperties(child, json, false);
                     if(isPrimaryType(child, ASSET_PRIMARY_TYPE)) {
                         String mimeType = child.getChild(JCR_CONTENT).getValueMap().get(JCR_MIME_TYPE, String.class);
                         json.writeAttribute(MIME_TYPE, mimeType);

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -26,7 +26,6 @@ package com.peregrine.admin.servlets;
  */
 
 import com.peregrine.commons.servlets.AbstractBaseServlet;
-import com.peregrine.commons.util.PerConstants;
 import com.peregrine.commons.util.PerUtil;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -40,8 +39,6 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Collection;
-import java.util.Locale;
 
 import static com.peregrine.admin.servlets.AdminPaths.RESOURCE_TYPE_NODES;
 import static com.peregrine.commons.util.PerConstants.*;

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -168,12 +168,6 @@ public class NodesServlet extends AbstractBaseServlet {
         writeIfFound(json, JCR_LAST_MODIFIED_BY, properties);
         writeIfFound(json, ALLOWED_OBJECTS, properties);
 
-        // Counting children is not a fast operation so we'll only do that on leaf nodes, which is
-        // the only place we care about them
-        if(withChildCount) {
-            json.writeAttribute(CHILD_COUNT, getChildCount(resource));
-        }
-
         // For the Replication data we need to obtain the content properties. If not found
         // then we try with the resoure's properties for non jcr:content nodes
         ValueMap replicationProperties = getProperties(resource);
@@ -188,17 +182,6 @@ public class NodesServlet extends AbstractBaseServlet {
             }
             json.writeAttribute(REPLICATION_STATUS, status);
         }
-    }
-
-    private int getChildCount(Resource resource) {
-        // Only way to get the child count it to count them directly
-        int numChildren = 0;
-        for(Resource child : resource.getChildren()) {
-            if(!JCR_CONTENT.equals(child.getName())) {
-                numChildren++;
-            }
-        }
-        return numChildren;
     }
 
     private String writeIfFound(JsonResponse json, String propertyName, ValueMap properties) throws IOException {

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -114,7 +114,7 @@ public class NodesServlet extends AbstractBaseServlet {
         Resource res = rs.getResource(path);
         json.writeAttribute(NAME,res.getName());
         json.writeAttribute(PATH,res.getPath());
-        writeProperties(res, json, false);
+        writeProperties(res, json);
         json.writeArray(CHILDREN);
         Iterable<Resource> children = res.getChildren();
         for(Resource child : children) {
@@ -127,7 +127,7 @@ public class NodesServlet extends AbstractBaseServlet {
                     json.writeObject();
                     json.writeAttribute(NAME,child.getName());
                     json.writeAttribute(PATH,child.getPath());
-                    writeProperties(child, json, false);
+                    writeProperties(child, json);
                     if(isPrimaryType(child, ASSET_PRIMARY_TYPE)) {
                         String mimeType = child.getChild(JCR_CONTENT).getValueMap().get(JCR_MIME_TYPE, String.class);
                         json.writeAttribute(MIME_TYPE, mimeType);
@@ -158,7 +158,7 @@ public class NodesServlet extends AbstractBaseServlet {
         json.writeClose();
     }
 
-    private void writeProperties(Resource resource, JsonResponse json, boolean withChildCount) throws IOException {
+    private void writeProperties(Resource resource, JsonResponse json) throws IOException {
         ValueMap properties = resource.getValueMap();
         writeIfFound(json, JCR_PRIMARY_TYPE, properties, RESOURCE_TYPE);
         writeIfFound(json, JCR_CREATED, properties);

--- a/admin-base/materialize/custom/_explorer.scss
+++ b/admin-base/materialize/custom/_explorer.scss
@@ -23,17 +23,27 @@
 					overflow-y: auto;
 					.collection-item {
 						position: relative;
+						padding: 10px 10px;
 						color: color("blue-grey", "darken-2");
 						border-color: color("blue-grey", "lighten-4");
-				    > span > a {
-				    	color: color("blue-grey", "darken-2");
-				    	&:hover,
-							&:focus,
+						&.dragging {
+							cursor: grabbing;
+						}
+						> span.draggable {
+							cursor: grab;
 							&:active {
-								color: color("blue-grey", "darken-4");
+								cursor: grabbing;
 							}
-				    }
-				    .material-icons {
+						}
+						> span > a {
+							color: color("blue-grey", "darken-2");
+							&:hover,
+								&:focus,
+								&:active {
+									color: color("blue-grey", "darken-4");
+								}
+						}
+						.material-icons {
 							vertical-align: middle;
 						}
 						.svg-icon {
@@ -218,7 +228,7 @@
 
 					}
 					&.preview-page {
-						
+
 					}
 				}
       	&.fullscreen {
@@ -264,8 +274,8 @@
 									stroke: color("blue-grey", "darken-3");
 								}
 							}
-							&:hover, 
-							&:focus, 
+							&:hover,
+							&:focus,
 							&:active {
 								background-color: color("blue-grey", "lighten-3");
 							}
@@ -317,7 +327,7 @@
 				}
 			}
 		}
-	}	
+	}
 	@media #{$extra-large-and-up} {
 		.explorer-layout {
 			.row {
@@ -330,5 +340,5 @@
 				}
 			}
 		}
-	}	
+	}
 }

--- a/admin-base/materialize/custom/_explorer.scss
+++ b/admin-base/materialize/custom/_explorer.scss
@@ -35,6 +35,22 @@
 								cursor: grabbing;
 							}
 						}
+						> span > a > span.numChildren:after {
+							position: absolute;
+							top: 14%;
+							left: 5%;
+							content: attr(data-count);
+							font-size: xx-small;
+							color: white;
+							padding: 0.6em;
+							border-radius: 50%;
+							line-height: 0.75em;
+							background: color("blue-grey","lighten-1");
+							text-align: center;
+							min-width: 2em;
+							font-weight: bold;
+							opacity: 0.8;
+						}
 						> span > a {
 							color: color("blue-grey", "darken-2");
 							&:hover,
@@ -73,10 +89,10 @@
 					    background-color: color("blue-grey", "lighten-5");
 						}
 						&.drop-after {
-							border-bottom: 1px solid color("orange", "lighten-3") !important;
+							border-bottom: 1px solid color("orange", "lighten-2") !important;
 						}
 						&.drop-before {
-							border-top: 1px solid color("orange", "lighten-3") !important;
+							border-top: 1px solid color("orange", "lighten-2") !important;
 							margin-top: -1px;
 						}
 						.secondary-content {

--- a/admin-base/materialize/custom/_explorer.scss
+++ b/admin-base/materialize/custom/_explorer.scss
@@ -35,22 +35,6 @@
 								cursor: grabbing;
 							}
 						}
-						> span > a > span.numChildren:after {
-							position: absolute;
-							top: 14%;
-							left: 5%;
-							content: attr(data-count);
-							font-size: xx-small;
-							color: white;
-							padding: 0.6em;
-							border-radius: 50%;
-							line-height: 0.75em;
-							background: color("blue-grey","lighten-1");
-							text-align: center;
-							min-width: 2em;
-							font-weight: bold;
-							opacity: 0.8;
-						}
 						> span > a {
 							color: color("blue-grey", "darken-2");
 							&:hover,

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
@@ -28,7 +28,7 @@
             v-if                    = "!model.type"
             v-bind:href             = "model.target +'.html'"
             v-bind:title            = "title"
-            v-on:click.stop.prevent = "action"
+            v-on:click.stop.prevent = "onClick"
             v-bind:class            = "model.classes">
             {{model.title}}
             <slot></slot>
@@ -80,6 +80,13 @@
      */
     export default {
     props: ['model'],
+    data: function() {
+        return {
+            clickCount: 0,
+            clickTimer: null,
+            dblClickDelay: 200
+        };
+    },
     computed: {
 
         /**
@@ -131,6 +138,26 @@
          */
         action: function(e) {
             $perAdminApp.action(this, this.model.command, this.model.target)
+        },
+        dblClickAction: function(e) {
+            $perAdminApp.action(this, this.model.dblClickCommand, this.model.dblClickTarget)
+        },
+        onClick: function(e) {
+            if(!this.model.dblClickCommand) {
+                this.action(e);
+            } else {
+                this.clickCount++;
+                if(this.clickCount === 1) {
+                    this.timer = setTimeout(() => {
+                        this.clickCount = 0;
+                        this.action(e);
+                    }, this.dblClickDelay);
+                } else {
+                    clearTimeout(this.timer);
+                    this.dblClickAction(e);
+                    this.clickCount = 0;
+                }
+            }
         }
     }
 }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/draghandle/.content.xml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/draghandle/.content.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  drag handle - UI Apps
+  %%
+  Copyright (C) 2017 headwire inc.
+  %%
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  #L%
+  -->
+
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+          jcr:primaryType="per:Component"
+          jcr:title="draghandle"
+          jcr:description=""
+/>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/draghandle/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/draghandle/template.vue
@@ -1,0 +1,38 @@
+<!--
+  #%L
+  drag handle - UI Apps
+  %%
+  Copyright (C) 2019 headwire inc.
+  %%
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  #L%
+  -->
+<template>
+    <span
+            class="draggable">
+        <i class="material-icons tiny">drag_handle</i>
+    </span>
+</template>
+
+<script>
+    export default {
+        props: ['model'],
+        computed: {
+        }
+    }
+</script>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -66,7 +66,6 @@
                                 command: 'selectPath',
                                 tooltipTitle: `select '${child.title || child.name}'`
                             }">
-                        <span v-if="hasChildren(child)" v-bind:data-count="child.childCount" class="numChildren">
                         </span><i class="material-icons">folder</i>
                     </admin-components-action>
 

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -74,6 +74,8 @@
                         v-bind:model="{
                             target: child.path,
                             command: 'editPage',
+                            dblClickTarget: child,
+                            dblClickCommand: 'selectPath',
                             tooltipTitle: `edit '${child.title || child.name}'`
                         }"><i class="material-icons">{{nodeTypeToIcon(child.resourceType)}}</i> {{child.title ? child.title : child.name}}
                     </admin-components-action>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -42,7 +42,7 @@
                             target: null,
                             command: 'selectParent',
                             tooltipTitle: $i18n('select parent')
-                        }"><i class="material-icons">folder</i> ..
+                        }"><i class="material-icons">folder_open</i> ..
                     </admin-components-action>
                 </li>
                 <li
@@ -56,10 +56,29 @@
                     v-on:dragenter.stop.prevent ="onDragEnterRow"
                     v-on:dragover.stop.prevent  ="onDragOverRow"
                     v-on:dragleave.stop.prevent ="onDragLeaveRow"
-                    v-on:drop.prevent      ="onDropRow(child, $event)"
-                    v-on:click.stop.prevent="selectItem(child)">
+                    v-on:drop.prevent      ="onDropRow(child, $event)">
+
                     <admin-components-draghandle/>
-                    <admin-components-action
+
+                    <admin-components-action v-if="editable(child)"
+                                             v-bind:model="{
+                                target: child,
+                                command: 'selectPath',
+                                tooltipTitle: `select '${child.title || child.name}'`
+                            }">
+                        <span v-if="hasChildren(child)" v-bind:data-count="child.childCount" class="numChildren">
+                        </span><i class="material-icons">folder</i>
+                    </admin-components-action>
+
+                    <admin-components-action v-if="editable(child)"
+                        v-bind:model="{
+                            target: child.path,
+                            command: 'editPage',
+                            tooltipTitle: `edit '${child.title || child.name}'`
+                        }"><i class="material-icons">{{nodeTypeToIcon(child.resourceType)}}</i> {{child.title ? child.title : child.name}}
+                    </admin-components-action>
+
+                    <admin-components-action v-if="!editable(child)"
                         v-bind:model="{
                             target: child,
                             command: 'selectPath',
@@ -287,7 +306,6 @@
             },
 
             onDropRow(item, ev, type) {
-                console.log('this.isSites: ', this.isSites)
                 if(this.isDraggingUiEl){
                     ev.target.classList.remove('drop-after','drop-before')
                     /* reorder row logic */
@@ -377,6 +395,9 @@
                 }
                 return false
 
+            },
+            hasChildren: function(child) {
+                return child && child.childCount && child.childCount > 0;
             },
             editable: function(child) {
                 return ['per:Page', 'per:Object'].indexOf(child.resourceType) >= 0

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -11,9 +11,9 @@
   to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
-  
+
   http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -45,19 +45,20 @@
                         }"><i class="material-icons">folder</i> ..
                     </admin-components-action>
                 </li>
-                <li 
-                    v-for ="(child,i) in children" 
+                <li
+                    v-for ="(child,i) in children"
                     v-bind:key="i"
-                    v-bind:class="`collection-item ${isSelected(child) ? 'explorer-item-selected' : ''}`"                    
-                    draggable ="true" 
+                    v-bind:class="`collection-item ${isSelected(child) ? 'explorer-item-selected' : ''}`"
+                    draggable ="true"
                     v-on:dragstart ="onDragRowStart(child,$event)"
                     v-on:drag      ="onDragRow"
                     v-on:dragend   ="onDragRowEnd(child,$event)"
                     v-on:dragenter.stop.prevent ="onDragEnterRow"
                     v-on:dragover.stop.prevent  ="onDragOverRow"
-                    v-on:dragleave.stop.prevent ="onDragLeaveRow" 
+                    v-on:dragleave.stop.prevent ="onDragLeaveRow"
                     v-on:drop.prevent      ="onDropRow(child, $event)"
                     v-on:click.stop.prevent="selectItem(child)">
+                    <admin-components-draghandle/>
                     <admin-components-action
                         v-bind:model="{
                             target: child,
@@ -70,8 +71,8 @@
 
                     <div class="secondary-content">
                         <admin-components-action v-if="editable(child)"
-                            v-bind:model="{ 
-                                target: child.path, 
+                            v-bind:model="{
+                                target: child.path,
                                 command: 'editPage',
                                 tooltipTitle: `edit '${child.title || child.name}'`
                             }">
@@ -97,7 +98,7 @@
                         </admin-components-action>
 
                         <span v-if="viewable(child)">
-                            <a 
+                            <a
                                 target      ="viewer"
                                 v-bind:href ="viewUrl(child)"
                                 v-on:click.stop  =""
@@ -144,8 +145,8 @@
             </div>
             <div class="progress-text">{{uploadProgress}}%</div>
             <div class="file-upload-action">
-                <button 
-                    type="button" 
+                <button
+                    type="button"
                     class="btn"
                     v-on:click="onDoneFileUpload">ok</button>
             </div>
@@ -252,13 +253,14 @@
             },
             /* row drag events */
             onDragRowStart(item, ev){
+                ev.srcElement.classList.add("dragging");
                 ev.dataTransfer.setData('text', item.path)
                 if(this.isDraggingFile){ this.isDraggingFile = false }
                 this.isDraggingUiEl = true
             },
 
             onDragRow(ev){
-
+                ev.srcElement.classList.remove("dragging");
             },
 
             onDragRowEnd(item, ev){
@@ -312,7 +314,7 @@
                     $perAdminApp.stateAction(action, {
                         path: ev.dataTransfer.getData("text"),
                         to: item.path,
-                        type: this.dropType 
+                        type: this.dropType
                     })
                 }
             },
@@ -331,7 +333,7 @@
 
             onDragLeaveExplorer(ev){
                 /* hide upload overlay */
-                /* TODO: fix upload unexpectedly closing 
+                /* TODO: fix upload unexpectedly closing
                 if(this.isDraggingFile){
                     this.isDraggingFile = false
                 }
@@ -350,23 +352,23 @@
 
             /* file upload */
             uploadFile(files) {
-              $perAdminApp.stateAction('uploadFiles', { 
-                path: $perAdminApp.getView().state.tools.assets, 
+              $perAdminApp.stateAction('uploadFiles', {
+                path: $perAdminApp.getView().state.tools.assets,
                 files: files,
                 cb: this.setUploadProgress
-              })    
+              })
             },
 
             setUploadProgress(percentCompleted){
-              this.uploadProgress = percentCompleted 
+              this.uploadProgress = percentCompleted
             },
-            
+
             onDoneFileUpload(){
                 this.isFileUploadVisible = false
                 this.uploadProgress = 0
             },
 
-            
+
             isSelected: function(child) {
                 if(this.model.selectionFrom && child) {
                     return $perAdminApp.getNodeFromViewOrNull(this.model.selectionFrom) === child.path

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/toolingpage.html
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/toolingpage/toolingpage.html
@@ -101,6 +101,7 @@
         $perAdminApp.loadComponent('admin-components-iconeditpage')
         $perAdminApp.loadComponent('admin-components-iconopenfolder')
         $perAdminApp.loadComponent('admin-components-iconrename')
+        $perAdminApp.loadComponent('admin-components-draghandle')
         $perAdminApp.loadComponent('admin-components-iconbrowser')
 
         $perAdminApp.loadComponent('pagerender-vue-components-placeholder')

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
@@ -44,6 +44,7 @@ public class PerConstants {
     public static final String ORDER_CHILD_TYPE = "child";
 
     public static final String ALLOWED_OBJECTS = "allowedObjects";
+    public static final String CHILD_COUNT = "childCount";
 
     public static final String DISTRIBUTION_SUB_SERVICE = "peregrine-distribution-sub-service";
 


### PR DESCRIPTION

PR for ticket #51 

In this branch:

- Style updates for explorer: added drag handle, changed cursor to indicate dragging (please note that Chrome and Firefox don't support css changes to cursor during drag, but Safari works nicely), some other minor CSS tweaks

- Change in behavior of explorer navigation: clicking on an item name edits the item (if applicable), added folder icon to drill down into folder.

- (currently turned off) Folder sub-item count badge display to show users how many items are in a folder. We need to figure out the best way to display this number, right now I am showing them as overlay numbers on the folder, but that UX is more suited to 'new item' that can be cleared. To see this work, change the call to writeProperties on line 130 of NodesServlet.java from writeProperties(child, json, false) to writeProperties(child, json, true);

If we decide not to use the display count, I'll remove the code that counts children.