### PR TITLE
Issues/54

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandler.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandler.java
@@ -1,11 +1,9 @@
 package com.peregrine.admin.resource;
 
-import com.peregrine.transform.ImageContext;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
 import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 import java.io.InputStream;
 import java.util.Map;
 

--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
@@ -116,7 +116,7 @@ public class AdminResourceHandlerService
     public static final String TARGET_SITE_EXISTS = "Target Site: '%s' does exist and so copy failed";
     public static final String SOURCE_SITE_IS_NOT_A_PAGE = "Source Site: '%s' is not a Page";
 
-    private static final Pattern URL_UNSAFE_CHARACTERS_PATTERN = Pattern.compile("[^0-9a-zA-Z$\\-_.+!]");
+    private static final Pattern URL_UNSAFE_CHARACTERS_PATTERN = Pattern.compile("[^0-9a-zA-Z\\-_]");
     private static final Pattern COMBINED_UNICODE_CHARACTER_PATTERN = Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
 
     static {

--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
@@ -22,13 +22,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.*;
-import javax.jcr.lock.LockException;
-import javax.jcr.nodetype.ConstraintViolationException;
-import javax.jcr.nodetype.NoSuchNodeTypeException;
-import javax.jcr.version.VersionException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import static com.peregrine.commons.util.PerConstants.*;
 import static com.peregrine.commons.util.PerUtil.convertToMap;
@@ -118,6 +116,9 @@ public class AdminResourceHandlerService
     public static final String TARGET_SITE_EXISTS = "Target Site: '%s' does exist and so copy failed";
     public static final String SOURCE_SITE_IS_NOT_A_PAGE = "Source Site: '%s' is not a Page";
 
+    private static final Pattern URL_UNSAFE_CHARACTERS_PATTERN = Pattern.compile("[^0-9a-zA-Z$\\-_.+!]");
+    private static final Pattern COMBINED_UNICODE_CHARACTER_PATTERN = Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
+
     static {
         IGNORED_PROPERTIES_FOR_COPY.add(JCR_PRIMARY_TYPE);
         IGNORED_PROPERTIES_FOR_COPY.add(JCR_UUID);
@@ -154,7 +155,7 @@ public class AdminResourceHandlerService
                 throw new ManagementException(String.format(NAME_UNDEFINED, FOLDER, parentPath));
             }
             Node parentNode =  parent.adaptTo(Node.class);
-            Node newFolder = parentNode.addNode(name, SLING_ORDERED_FOLDER);
+            Node newFolder = parentNode.addNode(sanitizeNodeName(name), SLING_ORDERED_FOLDER);
             newFolder.setProperty(JCR_TITLE, name);
             baseResourceHandler.updateModification(resourceResolver, newFolder);
             return resourceResolver.getResource(newFolder.getPath());
@@ -178,7 +179,7 @@ public class AdminResourceHandlerService
                 throw new ManagementException(String.format(RESOURCE_TYPE_UNEDEFINED, parentPath, name));
             }
             Node parentNode = parent.adaptTo(Node.class);
-            Node newObject = parentNode.addNode(name, OBJECT_PRIMARY_TYPE);
+            Node newObject = parentNode.addNode(sanitizeNodeName(name), OBJECT_PRIMARY_TYPE);
             newObject.setProperty(SLING_RESOURCE_TYPE, resourceType);
             newObject.setProperty(JCR_TITLE, name);
             baseResourceHandler.updateModification(resourceResolver, newObject);
@@ -717,7 +718,7 @@ public class AdminResourceHandlerService
     private void createResourceFromString(ResourceResolver resourceResolver, Resource parent, String name, String data) throws ManagementException {
         try {
             Node parentNode = parent.adaptTo(Node.class);
-            Node newAsset = parentNode.addNode(name, NT_FILE);
+            Node newAsset = parentNode.addNode(sanitizeNodeName(name), NT_FILE);
             Node content = newAsset.addNode(JCR_CONTENT, NT_RESOURCE);
             content.setProperty(JCR_DATA, data);
             content.setProperty(JCR_MIME_TYPE, TEXT_MIME_TYPE);
@@ -963,7 +964,7 @@ public class AdminResourceHandlerService
             Object value = entry.getValue();
             if(value instanceof Map) {
                 Map childProperties = (Map) value;
-                String childPath = (String) childProperties.get(PATH); 
+                String childPath = (String) childProperties.get(PATH);
                 Resource child = resource.getResourceResolver().getResource(childPath);
                 if(child == null) child = resource.getChild(name);
 
@@ -1138,7 +1139,7 @@ public class AdminResourceHandlerService
     private Node createPageOrTemplate(Resource parent, String name, String templateComponent, String templatePath) throws RepositoryException {
         Node parentNode = parent.adaptTo(Node.class);
         Node newPage = null;
-        newPage = parentNode.addNode(name, PAGE_PRIMARY_TYPE);
+        newPage = parentNode.addNode(sanitizeNodeName(name), PAGE_PRIMARY_TYPE);
         Node content = newPage.addNode(JCR_CONTENT);
         content.setPrimaryType(PAGE_CONTENT_TYPE);
         content.setProperty(SLING_RESOURCE_TYPE, templateComponent);
@@ -1148,5 +1149,21 @@ public class AdminResourceHandlerService
         }
         baseResourceHandler.updateModification(parent.getResourceResolver(), newPage);
         return newPage;
+    }
+
+    /**
+     * JCR/Jackrabbit is very open in what it accepts as names, but since we access these via URLs we need to limit
+     * the characters we use.
+     *
+     * @param name
+     * @return Name with
+     */
+    private String sanitizeNodeName(String name) {
+        // Using java.text.Normalizer and a regex, remove any diacritics or other combining characters (e.g., ń -> n, Ä -> A)
+        String result = COMBINED_UNICODE_CHARACTER_PATTERN.matcher(Normalizer.normalize(name, Normalizer.Form.NFD)).replaceAll("");
+
+        // Next, remove any characters that are not valid in URLS.
+        result = URL_UNSAFE_CHARACTERS_PATTERN.matcher(result).replaceAll("-");
+        return result;
     }
 }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/CreatePageServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/CreatePageServlet.java
@@ -37,13 +37,7 @@ import javax.servlet.Servlet;
 import java.io.IOException;
 
 import static com.peregrine.admin.servlets.AdminPaths.RESOURCE_TYPE_CREATION_PAGE;
-import static com.peregrine.commons.util.PerConstants.CREATED;
-import static com.peregrine.commons.util.PerConstants.NAME;
-import static com.peregrine.commons.util.PerConstants.PAGE;
-import static com.peregrine.commons.util.PerConstants.PATH;
-import static com.peregrine.commons.util.PerConstants.STATUS;
-import static com.peregrine.commons.util.PerConstants.TEMPLATE_PATH;
-import static com.peregrine.commons.util.PerConstants.TYPE;
+import static com.peregrine.commons.util.PerConstants.*;
 import static com.peregrine.commons.util.PerUtil.EQUALS;
 import static com.peregrine.commons.util.PerUtil.PER_PREFIX;
 import static com.peregrine.commons.util.PerUtil.PER_VENDOR;
@@ -89,7 +83,7 @@ public class CreatePageServlet extends AbstractBaseServlet {
             request.getResourceResolver().commit();
             return new JsonResponse()
                 .writeAttribute(TYPE, PAGE).writeAttribute(STATUS, CREATED)
-                .writeAttribute(NAME, name).writeAttribute(PATH, newPage.getPath()).writeAttribute(TEMPLATE_PATH, templatePath);
+                .writeAttribute(NAME, newPage.getName()).writeAttribute(DISPLAY_NAME, name).writeAttribute(PATH, newPage.getPath()).writeAttribute(TEMPLATE_PATH, templatePath);
         } catch (ManagementException e) {
             return new ErrorResponse().setHttpErrorCode(SC_BAD_REQUEST).setErrorMessage(FAILED_TO_CREATE_PAGE).setRequestPath(parentPath).setException(e);
         }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -133,6 +133,12 @@ public class NodesServlet extends AbstractBaseServlet {
                     if(isPrimaryType(child, PAGE_PRIMARY_TYPE)) {
                         writeJcrContent(child, json);
                     }
+
+                    if(isPrimaryType(child, OBJECT_PRIMARY_TYPE)) {
+                        String title = child.getValueMap().get(JCR_TITLE, String.class);
+                        json.writeAttribute(TITLE, title);
+                    }
+
                     json.writeClose();
                 }
             }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -134,7 +134,7 @@ public class NodesServlet extends AbstractBaseServlet {
                         writeJcrContent(child, json);
                     }
 
-                    if(isPrimaryType(child, OBJECT_PRIMARY_TYPE)) {
+                    if(isPrimaryType(child, OBJECT_PRIMARY_TYPE, ASSET_PRIMARY_TYPE, SLING_ORDERED_FOLDER)) {
                         String title = child.getValueMap().get(JCR_TITLE, String.class);
                         json.writeAttribute(TITLE, title);
                     }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -117,6 +117,7 @@ public class NodesServlet extends AbstractBaseServlet {
         for(Resource child : children) {
             if(fullPath.startsWith(child.getPath())) {
                 json.writeObject();
+                writeJcrContent(child, json);
                 convertResource(json, rs, segments, pos+1, fullPath);
                 json.writeClose();
             } else {
@@ -130,29 +131,37 @@ public class NodesServlet extends AbstractBaseServlet {
                         json.writeAttribute(MIME_TYPE, mimeType);
                     }
                     if(isPrimaryType(child, PAGE_PRIMARY_TYPE)) {
-                        Resource content = child.getChild(JCR_CONTENT);
-                        if(content != null) {
-                            for (String key: content.getValueMap().keySet()) {
-                                if(key.equals(JCR_TITLE)) {
-                                    String title = content.getValueMap().get(JCR_TITLE, String.class);
-                                    json.writeAttribute(TITLE, title);
-                                } else {
-                                    if(key.indexOf(":") < 0) {
-                                        json.writeAttribute(key, content.getValueMap().get(key, String.class));
-                                    }
-                                }
-                            }
-                            String component = PerUtil.getComponentNameFromResource(content);
-                            json.writeAttribute(COMPONENT, component);
-                        } else {
-                            logger.debug("No Content Child found for: '{}'", child.getPath());
-                        }
+                        writeJcrContent(child, json);
                     }
                     json.writeClose();
                 }
             }
         }
         json.writeClose();
+    }
+
+    private void writeJcrContent(Resource resource, JsonResponse json) throws IOException {
+        Resource content = resource.getChild(JCR_CONTENT);
+
+        if(content != null) {
+            for (String key: content.getValueMap().keySet()) {
+                if(key.equals(JCR_TITLE)) {
+                    String title = content.getValueMap().get(JCR_TITLE, String.class);
+                    json.writeAttribute(TITLE, title);
+                } else if(key.equals(NAME)) {
+                    String title = content.getValueMap().get(NAME, String.class);
+                    json.writeAttribute(DISPLAY_NAME, title);
+                } else {
+                    if(key.indexOf(":") < 0) {
+                        json.writeAttribute(key, content.getValueMap().get(key, String.class));
+                    }
+                }
+            }
+            String component = PerUtil.getComponentNameFromResource(content);
+            json.writeAttribute(COMPONENT, component);
+        } else {
+            logger.debug("No Content Child found for: '{}'", resource.getPath());
+        }
     }
 
     private void writeProperties(Resource resource, JsonResponse json) throws IOException {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetbrowser/template.vue
@@ -272,7 +272,6 @@
             nodes() {
                 let view = $perAdminApp.getView()
                 let nodes = view.admin.pathBrowser
-                console.log('view.admin: ', view.admin)
                 if(nodes && this.path) {
                     let nodesFromPath = $perAdminApp.findNodeFromPath(nodes, this.path)
                     console.log('nodesFromPath: ', nodesFromPath)
@@ -281,7 +280,6 @@
                 return {}
             },
             list(){
-                console.log('list: ', this.nodes.children)
                 return this.nodes.children || []
             }
         },

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
@@ -153,13 +153,17 @@
 
                 return this.validateTabOne(this);
             },
+            sanitizeNodeName(name) {
+                return $perAdminApp.getSanitizedNodeName(name);
+            },
             nameAvailable(value) {
                 if(!value || value.length === 0) {
                     return ['name is required']
                 } else {
                     const folder = $perAdminApp.findNodeFromPath($perAdminApp.getView().admin.nodes, this.formmodel.path)
+
                     for(let i = 0; i < folder.children.length; i++) {
-                        if(folder.children[i].name === value) {
+                        if(this.sanitizeNodeName(folder.children[i].name) === this.sanitizeNodeName(value)) {
                             return ['name aready in use']
                         }
                     }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
@@ -171,7 +171,7 @@
                 }
             },
             leaveTabTwo: function() {
-                return this.$refs.nameTab.validate()
+                return (this.nameAvailable(this.formmodel.name).length == 0) && this.$refs.nameTab.validate();
             }
 
         }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -66,7 +66,7 @@
                                 command: 'selectPath',
                                 tooltipTitle: `select '${child.title || child.name}'`
                             }">
-                        </span><i class="material-icons">folder</i>
+                        <i class="material-icons">folder</i>
                     </admin-components-action>
 
                     <admin-components-action v-if="editable(child)"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathfield/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathfield/template.vue
@@ -28,7 +28,7 @@
             /&nbsp;<admin-components-action
                 v-bind:model="{
                     target: { path: item.path },
-                    title: item.name,
+                    title: item.title || item.name,
                     command: 'selectPathInNav'
                 }"></admin-components-action>&nbsp;
         </template>
@@ -48,7 +48,15 @@
                 var segments = this.path.toString().split('/')
                 var ret = []
                 for(var i = 2; i < segments.length; i++) {
-                    ret.push( { name: segments[i], path: segments.slice(0, i+1).join('/') } )
+                    let node = $perAdminApp.findNodeFromPath($perAdminApp.getView().admin.nodes, segments.slice(0, i+1).join('/'));
+
+                    if(node) {
+                        ret.push( {
+                            name: segments[i],
+                            path: node.path,
+                            title: node.title
+                        } );
+                    }
                 }
                 return ret;
             }

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -366,7 +366,7 @@ class PerAdminImpl {
 
     createObject(parentPath, name, templatePath) {
         return new Promise( (resolve, reject) => {
-            let data = new FormData()
+            let data = new UTF8FormData();
             data.append('name', name)
             data.append('templatePath', templatePath)
             updateWithForm('/admin/createObject.json'+parentPath, data)

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -343,7 +343,7 @@ class PerAdminImpl {
 
     createSite(fromName, toName) {
         return new Promise( (resolve, reject) => {
-            let data = new FormData()
+            let data = new UTF8FormData()
             data.append('fromSite', fromName)
             data.append('toSite', toName)
             updateWithForm('/admin/createSite.json', data)

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -487,7 +487,7 @@ class PerAdminImpl {
 
     createFolder(parentPath, name) {
         return new Promise( (resolve, reject) => {
-            let data = new FormData()
+            let data = new UTF8FormData()
             data.append('name', name)
             updateWithForm('/admin/createFolder.json'+parentPath, data)
                 .then( (data) => this.populateNodesForBrowser(parentPath) )

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -27,7 +27,7 @@
 import { LoggerFactory } from './logger'
 let logger = LoggerFactory.logger('apiImpl').setLevelDebug()
 
-import { stripNulls} from './utils'
+import { stripNulls, UTF8FormData} from './utils'
 
 const API_BASE = '/perapi'
 const postConfig = {
@@ -354,9 +354,10 @@ class PerAdminImpl {
 
     createPage(parentPath, name, templatePath) {
         return new Promise( (resolve, reject) => {
-            let data = new FormData()
-            data.append('name', name)
+            let data = new UTF8FormData()
+            data.append('name', name);
             data.append('templatePath', templatePath)
+
             updateWithForm('/admin/createPage.json'+parentPath, data)
                 .then( (data) => this.populateNodesForBrowser(parentPath) )
                 .then( () => resolve() )

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -354,7 +354,7 @@ class PerAdminImpl {
 
     createPage(parentPath, name, templatePath) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData()
+            let data = new UTF8FormData();
             data.append('name', name);
             data.append('templatePath', templatePath)
 
@@ -476,7 +476,7 @@ class PerAdminImpl {
 
     createTemplate(parentPath, name, component) {
         return new Promise( (resolve, reject) => {
-            let data = new FormData()
+            let data = new UTF8FormData();
             data.append('name', name)
             data.append('component', component)
             updateWithForm('/admin/createTemplate.json'+parentPath, data)

--- a/admin-base/ui.apps/src/main/js/perAdminApp.js
+++ b/admin-base/ui.apps/src/main/js/perAdminApp.js
@@ -43,7 +43,7 @@ let logger = LoggerFactory.logger('perAdminApp').setLevelDebug()
 
 import PeregrineApi from './api'
 import PerAdminImpl from './apiImpl'
-import {makePathInfo, pagePathToDataPath, set, get} from './utils'
+import {makePathInfo, pagePathToDataPath, set, get, sanitizeNodeName} from './utils'
 
 import StateActions from './stateActions'
 
@@ -920,8 +920,11 @@ var PerAdminApp = {
 
     beforeStateAction(fun) {
         beforeStateActionImpl(fun)
-    }
+    },
 
+    getSanitizedNodeName(name) {
+        return sanitizeNodeName(name);
+    }
 }
 
 export default PerAdminApp

--- a/admin-base/ui.apps/src/main/js/stateActions/createObject.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/createObject.js
@@ -24,6 +24,7 @@
  */
 import { LoggerFactory } from '../logger'
 import {SUFFIX_PARAM_SEPARATOR} from "../constants";
+import {sanitizeNodeName} from '../utils'
 let log = LoggerFactory.logger('createObject').setLevelDebug()
 
 export default function(me, target) {
@@ -32,6 +33,7 @@ export default function(me, target) {
     var api = me.getApi()
     return api.createObject(target.parent, target.name, target.template).then( () => {
         if(target.data) {
+            target.name = sanitizeNodeName(target.name);
             api.saveObjectEdit(target.parent + '/' + target.name, target.data).then( () => {
                 if(target.returnTo) {
                     me.loadContent(target.returnTo+'.html/path' +SUFFIX_PARAM_SEPARATOR + target.parent)

--- a/admin-base/ui.apps/src/main/js/stateActions/createPage.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/createPage.js
@@ -24,14 +24,18 @@
  */
 import { LoggerFactory } from '../logger'
 import {SUFFIX_PARAM_SEPARATOR} from "../constants";
+import {sanitizeNodeName} from '../utils'
 let log = LoggerFactory.logger('createPage').setLevelDebug()
 
 export default function(me, target) {
-
     log.fine(target)
     var api = me.getApi()
-    api.createPage(target.parent, target.name, target.template).then( () => {
-        target.data.path = '/jcr:content'
+    api.createPage(target.parent, target.name, target.template).then( (a1, a2, a3) => {
+        target.data.path = '/jcr:content';
+        // This has been persisted, so the node name may have changed from what we pass in.
+        // Probably would be better if this were read from the server response instead.
+        target.name = sanitizeNodeName(target.name);
+
         api.savePageEdit(target.parent + '/' + target.name, target.data).then( () => {
             me.loadContent('/content/admin/pages.html/path' + SUFFIX_PARAM_SEPARATOR + target.parent)
         })

--- a/admin-base/ui.apps/src/main/js/stateActions/createPage.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/createPage.js
@@ -30,7 +30,7 @@ let log = LoggerFactory.logger('createPage').setLevelDebug()
 export default function(me, target) {
     log.fine(target)
     var api = me.getApi()
-    api.createPage(target.parent, target.name, target.template).then( (a1, a2, a3) => {
+    api.createPage(target.parent, target.name, target.template).then( () => {
         target.data.path = '/jcr:content';
         // This has been persisted, so the node name may have changed from what we pass in.
         // Probably would be better if this were read from the server response instead.

--- a/admin-base/ui.apps/src/main/js/utils.js
+++ b/admin-base/ui.apps/src/main/js/utils.js
@@ -135,3 +135,23 @@ export function stripNulls(data) {
         }
     }
 }
+
+export function sanitizeNodeName(name) {
+    // Here we String.prototype.normalize to normalize characters with diacritics to combined chars,
+    // then call replace with the correct Unicode block to remove those combining characters (i.e., ń -> n, Ä -> A)
+    // Lastly, any remaining characters that are not valid in URLs are removed
+    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^0-9a-zA-Z$\-_.+!]/g,"-");
+}
+
+
+// Per sling documentation, (https://sling.apache.org/documentation/the-sling-engine/request-parameters.html)
+// sling expects a _charset_ field in the formdata (not request header!), otherwise it will use the Servlet
+// standard of ISO-8859-1. Using this instead of standard FormData() will pre-set that form value
+export class UTF8FormData extends FormData {
+    // noinspection JSAnnotator
+    constructor() {
+        let fd = new FormData();
+        fd.append('_charset_', 'UTF-8');
+        return fd;
+    }
+}

--- a/admin-base/ui.apps/src/main/js/utils.js
+++ b/admin-base/ui.apps/src/main/js/utils.js
@@ -140,7 +140,7 @@ export function sanitizeNodeName(name) {
     // Here we String.prototype.normalize to normalize characters with diacritics to combined chars,
     // then call replace with the correct Unicode block to remove those combining characters (i.e., ń -> n, Ä -> A)
     // Lastly, any remaining characters that are not valid in URLs are removed
-    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^0-9a-zA-Z$\-_.+!]/g,"-");
+    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^0-9a-zA-Z-_]/g,"-");
 }
 
 

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
@@ -1,6 +1,7 @@
 package com.peregrine.commons.util;
 
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * Commonly used Constants in Peregrine
@@ -86,6 +87,7 @@ public class PerConstants {
     public static final String VARIATIONS = "__variations";
     public static final String STATUS = "status";
     public static final String TEMPLATE_PATH = "templatePath";
+    public static final String DISPLAY_NAME = "displayName";
     public static final String SOURCE_PATH = "sourcePath";
     public static final String CREATED = "created";
     public static final String DELETED = "deleted";

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerUtil.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerUtil.java
@@ -543,16 +543,16 @@ public class PerUtil {
     /**
      * Check if the given resource has that Primary Type
      * @param resource Resource to be checked. It will test this resource and not go down to JCR Content
-     * @param primaryType Primary Type to test. If null or empty this method returns false
-     * @return true if the resource contains a Primary Type that matches the given value
+     * @param primaryTypes Primary Types to test. If null or empty this method returns false
+     * @return true if the resource contains a Primary Type that matches one of the given values
      */
-    public static boolean isPrimaryType(Resource resource, String primaryType) {
-        String answer = null;
+    public static boolean isPrimaryType(Resource resource, String... primaryTypes) {
+        String primaryResourceType = null;
         if(resource != null) {
             ValueMap properties = getProperties(resource, false);
-            answer = properties.get(JCR_PRIMARY_TYPE, String.class);
+            primaryResourceType = properties.get(JCR_PRIMARY_TYPE, String.class);
         }
-        return answer != null && answer.equals(primaryType);
+        return primaryResourceType != null && Arrays.asList(primaryTypes).contains(primaryResourceType);
     }
 
     /**


### PR DESCRIPTION
Handles issue #54 

In this PR:

- Node names are filtered to only allow URL-friendly characters, but we now distinguish between the node name and title/"display name". Node names can only have alphanumeric and a few other URL-safe characters, while display name can contain any unicode characters. When a user types in a name containing special characters, these are filtered out for the URL values, but in the explorer and elsewhere they will see the name as they typed it. e.g., if a user names a node "hello, world?", the node will be internally named "hello--world-", but the user will only see "hello, world?" outside the URL and composum.

- Combining characters are gracefully handled when filtering the node name; instead of dashes, the closes ISO-8559-1 character is used where possible; e.g., "hēllo?" becomes "hello-"

- The "name available" box on the page wizard now blocks moving forward if the name is taken. This check is aware of the updates above, so if there is a node named "hēllo?" and the user enters "hêllo&", this will block, as "hēllo?" and "hêllo&" would both become "hello-" when the node is written.


A few things to note here:

1. Per https://sling.apache.org/documentation/the-sling-engine/request-parameters.html#character-encoding, sling expects forms to have a "\_charset\_" field; the sling servlet will look for this and interpret parameters based on the encoding. Since apiImpl mainly calls servlets by manually creating a FormData object and posting it, I created the util class UTF8FormData in utils.js, which is just a FormData object with \_charset\_ set to UTF8. 

2. To handle accented and other combining characters in a way that kept the URLs readable, I normalized the text to split it into base characters and diacritics, then filtered out the latter. See https://docs.oracle.com/javase/tutorial/i18n/text/normalizerapi.html for info on the first step of that. I  implemented this both in Java and in Javascript -- I think that the job of handling such characters should be done primarily on the server side; the client should only send one name parameter (as opposed to the client sending separate 'nodeName' and 'displayName' params) and let the server sanitize as needed. However, when we are using javascript to check if a name is a duplicate, we need to know how the server will be massaging the data, so the same method is needed on the front end.