### PR TITLE
Revert "Issues/54"

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandler.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandler.java
@@ -1,9 +1,11 @@
 package com.peregrine.admin.resource;
 
+import com.peregrine.transform.ImageContext;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
 import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 import java.io.InputStream;
 import java.util.Map;
 

--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/AdminResourceHandlerService.java
@@ -22,10 +22,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.*;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.version.VersionException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -33,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.UUID;
-import java.util.regex.Pattern;
 
 import static com.peregrine.commons.util.PerConstants.*;
 import static com.peregrine.commons.util.PerUtil.convertToMap;
@@ -116,9 +118,6 @@ public class AdminResourceHandlerService
     public static final String TARGET_SITE_EXISTS = "Target Site: '%s' does exist and so copy failed";
     public static final String SOURCE_SITE_IS_NOT_A_PAGE = "Source Site: '%s' is not a Page";
 
-    private static final Pattern URL_UNSAFE_CHARACTERS_PATTERN = Pattern.compile("[^0-9a-zA-Z\\-_]");
-    private static final Pattern COMBINED_UNICODE_CHARACTER_PATTERN = Pattern.compile("[\\p{InCombiningDiacriticalMarks}\\p{IsLm}\\p{IsSk}]+");
-
     static {
         IGNORED_PROPERTIES_FOR_COPY.add(JCR_PRIMARY_TYPE);
         IGNORED_PROPERTIES_FOR_COPY.add(JCR_UUID);
@@ -155,7 +154,7 @@ public class AdminResourceHandlerService
                 throw new ManagementException(String.format(NAME_UNDEFINED, FOLDER, parentPath));
             }
             Node parentNode =  parent.adaptTo(Node.class);
-            Node newFolder = parentNode.addNode(sanitizeNodeName(name), SLING_ORDERED_FOLDER);
+            Node newFolder = parentNode.addNode(name, SLING_ORDERED_FOLDER);
             newFolder.setProperty(JCR_TITLE, name);
             baseResourceHandler.updateModification(resourceResolver, newFolder);
             return resourceResolver.getResource(newFolder.getPath());
@@ -179,7 +178,7 @@ public class AdminResourceHandlerService
                 throw new ManagementException(String.format(RESOURCE_TYPE_UNEDEFINED, parentPath, name));
             }
             Node parentNode = parent.adaptTo(Node.class);
-            Node newObject = parentNode.addNode(sanitizeNodeName(name), OBJECT_PRIMARY_TYPE);
+            Node newObject = parentNode.addNode(name, OBJECT_PRIMARY_TYPE);
             newObject.setProperty(SLING_RESOURCE_TYPE, resourceType);
             newObject.setProperty(JCR_TITLE, name);
             baseResourceHandler.updateModification(resourceResolver, newObject);
@@ -718,7 +717,7 @@ public class AdminResourceHandlerService
     private void createResourceFromString(ResourceResolver resourceResolver, Resource parent, String name, String data) throws ManagementException {
         try {
             Node parentNode = parent.adaptTo(Node.class);
-            Node newAsset = parentNode.addNode(sanitizeNodeName(name), NT_FILE);
+            Node newAsset = parentNode.addNode(name, NT_FILE);
             Node content = newAsset.addNode(JCR_CONTENT, NT_RESOURCE);
             content.setProperty(JCR_DATA, data);
             content.setProperty(JCR_MIME_TYPE, TEXT_MIME_TYPE);
@@ -964,7 +963,7 @@ public class AdminResourceHandlerService
             Object value = entry.getValue();
             if(value instanceof Map) {
                 Map childProperties = (Map) value;
-                String childPath = (String) childProperties.get(PATH);
+                String childPath = (String) childProperties.get(PATH); 
                 Resource child = resource.getResourceResolver().getResource(childPath);
                 if(child == null) child = resource.getChild(name);
 
@@ -1139,7 +1138,7 @@ public class AdminResourceHandlerService
     private Node createPageOrTemplate(Resource parent, String name, String templateComponent, String templatePath) throws RepositoryException {
         Node parentNode = parent.adaptTo(Node.class);
         Node newPage = null;
-        newPage = parentNode.addNode(sanitizeNodeName(name), PAGE_PRIMARY_TYPE);
+        newPage = parentNode.addNode(name, PAGE_PRIMARY_TYPE);
         Node content = newPage.addNode(JCR_CONTENT);
         content.setPrimaryType(PAGE_CONTENT_TYPE);
         content.setProperty(SLING_RESOURCE_TYPE, templateComponent);
@@ -1149,21 +1148,5 @@ public class AdminResourceHandlerService
         }
         baseResourceHandler.updateModification(parent.getResourceResolver(), newPage);
         return newPage;
-    }
-
-    /**
-     * JCR/Jackrabbit is very open in what it accepts as names, but since we access these via URLs we need to limit
-     * the characters we use.
-     *
-     * @param name
-     * @return Name with
-     */
-    private String sanitizeNodeName(String name) {
-        // Using java.text.Normalizer and a regex, remove any diacritics or other combining characters (e.g., ń -> n, Ä -> A)
-        String result = COMBINED_UNICODE_CHARACTER_PATTERN.matcher(Normalizer.normalize(name, Normalizer.Form.NFD)).replaceAll("");
-
-        // Next, remove any characters that are not valid in URLS.
-        result = URL_UNSAFE_CHARACTERS_PATTERN.matcher(result).replaceAll("-");
-        return result;
     }
 }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/CreatePageServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/CreatePageServlet.java
@@ -37,7 +37,13 @@ import javax.servlet.Servlet;
 import java.io.IOException;
 
 import static com.peregrine.admin.servlets.AdminPaths.RESOURCE_TYPE_CREATION_PAGE;
-import static com.peregrine.commons.util.PerConstants.*;
+import static com.peregrine.commons.util.PerConstants.CREATED;
+import static com.peregrine.commons.util.PerConstants.NAME;
+import static com.peregrine.commons.util.PerConstants.PAGE;
+import static com.peregrine.commons.util.PerConstants.PATH;
+import static com.peregrine.commons.util.PerConstants.STATUS;
+import static com.peregrine.commons.util.PerConstants.TEMPLATE_PATH;
+import static com.peregrine.commons.util.PerConstants.TYPE;
 import static com.peregrine.commons.util.PerUtil.EQUALS;
 import static com.peregrine.commons.util.PerUtil.PER_PREFIX;
 import static com.peregrine.commons.util.PerUtil.PER_VENDOR;
@@ -83,7 +89,7 @@ public class CreatePageServlet extends AbstractBaseServlet {
             request.getResourceResolver().commit();
             return new JsonResponse()
                 .writeAttribute(TYPE, PAGE).writeAttribute(STATUS, CREATED)
-                .writeAttribute(NAME, newPage.getName()).writeAttribute(DISPLAY_NAME, name).writeAttribute(PATH, newPage.getPath()).writeAttribute(TEMPLATE_PATH, templatePath);
+                .writeAttribute(NAME, name).writeAttribute(PATH, newPage.getPath()).writeAttribute(TEMPLATE_PATH, templatePath);
         } catch (ManagementException e) {
             return new ErrorResponse().setHttpErrorCode(SC_BAD_REQUEST).setErrorMessage(FAILED_TO_CREATE_PAGE).setRequestPath(parentPath).setException(e);
         }

--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/NodesServlet.java
@@ -117,7 +117,6 @@ public class NodesServlet extends AbstractBaseServlet {
         for(Resource child : children) {
             if(fullPath.startsWith(child.getPath())) {
                 json.writeObject();
-                writeJcrContent(child, json);
                 convertResource(json, rs, segments, pos+1, fullPath);
                 json.writeClose();
             } else {
@@ -131,43 +130,29 @@ public class NodesServlet extends AbstractBaseServlet {
                         json.writeAttribute(MIME_TYPE, mimeType);
                     }
                     if(isPrimaryType(child, PAGE_PRIMARY_TYPE)) {
-                        writeJcrContent(child, json);
+                        Resource content = child.getChild(JCR_CONTENT);
+                        if(content != null) {
+                            for (String key: content.getValueMap().keySet()) {
+                                if(key.equals(JCR_TITLE)) {
+                                    String title = content.getValueMap().get(JCR_TITLE, String.class);
+                                    json.writeAttribute(TITLE, title);
+                                } else {
+                                    if(key.indexOf(":") < 0) {
+                                        json.writeAttribute(key, content.getValueMap().get(key, String.class));
+                                    }
+                                }
+                            }
+                            String component = PerUtil.getComponentNameFromResource(content);
+                            json.writeAttribute(COMPONENT, component);
+                        } else {
+                            logger.debug("No Content Child found for: '{}'", child.getPath());
+                        }
                     }
-
-                    if(isPrimaryType(child, OBJECT_PRIMARY_TYPE, ASSET_PRIMARY_TYPE, SLING_ORDERED_FOLDER)) {
-                        String title = child.getValueMap().get(JCR_TITLE, String.class);
-                        json.writeAttribute(TITLE, title);
-                    }
-
                     json.writeClose();
                 }
             }
         }
         json.writeClose();
-    }
-
-    private void writeJcrContent(Resource resource, JsonResponse json) throws IOException {
-        Resource content = resource.getChild(JCR_CONTENT);
-
-        if(content != null) {
-            for (String key: content.getValueMap().keySet()) {
-                if(key.equals(JCR_TITLE)) {
-                    String title = content.getValueMap().get(JCR_TITLE, String.class);
-                    json.writeAttribute(TITLE, title);
-                } else if(key.equals(NAME)) {
-                    String title = content.getValueMap().get(NAME, String.class);
-                    json.writeAttribute(DISPLAY_NAME, title);
-                } else {
-                    if(key.indexOf(":") < 0) {
-                        json.writeAttribute(key, content.getValueMap().get(key, String.class));
-                    }
-                }
-            }
-            String component = PerUtil.getComponentNameFromResource(content);
-            json.writeAttribute(COMPONENT, component);
-        } else {
-            logger.debug("No Content Child found for: '{}'", resource.getPath());
-        }
     }
 
     private void writeProperties(Resource resource, JsonResponse json) throws IOException {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetbrowser/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/assetbrowser/template.vue
@@ -272,6 +272,7 @@
             nodes() {
                 let view = $perAdminApp.getView()
                 let nodes = view.admin.pathBrowser
+                console.log('view.admin: ', view.admin)
                 if(nodes && this.path) {
                     let nodesFromPath = $perAdminApp.findNodeFromPath(nodes, this.path)
                     console.log('nodesFromPath: ', nodesFromPath)
@@ -280,6 +281,7 @@
                 return {}
             },
             list(){
+                console.log('list: ', this.nodes.children)
                 return this.nodes.children || []
             }
         },

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/createpagewizard/template.vue
@@ -153,17 +153,13 @@
 
                 return this.validateTabOne(this);
             },
-            sanitizeNodeName(name) {
-                return $perAdminApp.getSanitizedNodeName(name);
-            },
             nameAvailable(value) {
                 if(!value || value.length === 0) {
                     return ['name is required']
                 } else {
                     const folder = $perAdminApp.findNodeFromPath($perAdminApp.getView().admin.nodes, this.formmodel.path)
-
                     for(let i = 0; i < folder.children.length; i++) {
-                        if(this.sanitizeNodeName(folder.children[i].name) === this.sanitizeNodeName(value)) {
+                        if(folder.children[i].name === value) {
                             return ['name aready in use']
                         }
                     }
@@ -171,7 +167,7 @@
                 }
             },
             leaveTabTwo: function() {
-                return (this.nameAvailable(this.formmodel.name).length == 0) && this.$refs.nameTab.validate();
+                return this.$refs.nameTab.validate()
             }
 
         }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -66,7 +66,7 @@
                                 command: 'selectPath',
                                 tooltipTitle: `select '${child.title || child.name}'`
                             }">
-                        <i class="material-icons">folder</i>
+                        </span><i class="material-icons">folder</i>
                     </admin-components-action>
 
                     <admin-components-action v-if="editable(child)"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathfield/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/pathfield/template.vue
@@ -28,7 +28,7 @@
             /&nbsp;<admin-components-action
                 v-bind:model="{
                     target: { path: item.path },
-                    title: item.title || item.name,
+                    title: item.name,
                     command: 'selectPathInNav'
                 }"></admin-components-action>&nbsp;
         </template>
@@ -48,15 +48,7 @@
                 var segments = this.path.toString().split('/')
                 var ret = []
                 for(var i = 2; i < segments.length; i++) {
-                    let node = $perAdminApp.findNodeFromPath($perAdminApp.getView().admin.nodes, segments.slice(0, i+1).join('/'));
-
-                    if(node) {
-                        ret.push( {
-                            name: segments[i],
-                            path: node.path,
-                            title: node.title
-                        } );
-                    }
+                    ret.push( { name: segments[i], path: segments.slice(0, i+1).join('/') } )
                 }
                 return ret;
             }

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -27,7 +27,7 @@
 import { LoggerFactory } from './logger'
 let logger = LoggerFactory.logger('apiImpl').setLevelDebug()
 
-import { stripNulls, UTF8FormData} from './utils'
+import { stripNulls} from './utils'
 
 const API_BASE = '/perapi'
 const postConfig = {
@@ -343,7 +343,7 @@ class PerAdminImpl {
 
     createSite(fromName, toName) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData()
+            let data = new FormData()
             data.append('fromSite', fromName)
             data.append('toSite', toName)
             updateWithForm('/admin/createSite.json', data)
@@ -354,10 +354,9 @@ class PerAdminImpl {
 
     createPage(parentPath, name, templatePath) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData();
-            data.append('name', name);
+            let data = new FormData()
+            data.append('name', name)
             data.append('templatePath', templatePath)
-
             updateWithForm('/admin/createPage.json'+parentPath, data)
                 .then( (data) => this.populateNodesForBrowser(parentPath) )
                 .then( () => resolve() )
@@ -366,7 +365,7 @@ class PerAdminImpl {
 
     createObject(parentPath, name, templatePath) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData();
+            let data = new FormData()
             data.append('name', name)
             data.append('templatePath', templatePath)
             updateWithForm('/admin/createObject.json'+parentPath, data)
@@ -476,7 +475,7 @@ class PerAdminImpl {
 
     createTemplate(parentPath, name, component) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData();
+            let data = new FormData()
             data.append('name', name)
             data.append('component', component)
             updateWithForm('/admin/createTemplate.json'+parentPath, data)
@@ -487,7 +486,7 @@ class PerAdminImpl {
 
     createFolder(parentPath, name) {
         return new Promise( (resolve, reject) => {
-            let data = new UTF8FormData()
+            let data = new FormData()
             data.append('name', name)
             updateWithForm('/admin/createFolder.json'+parentPath, data)
                 .then( (data) => this.populateNodesForBrowser(parentPath) )

--- a/admin-base/ui.apps/src/main/js/perAdminApp.js
+++ b/admin-base/ui.apps/src/main/js/perAdminApp.js
@@ -43,7 +43,7 @@ let logger = LoggerFactory.logger('perAdminApp').setLevelDebug()
 
 import PeregrineApi from './api'
 import PerAdminImpl from './apiImpl'
-import {makePathInfo, pagePathToDataPath, set, get, sanitizeNodeName} from './utils'
+import {makePathInfo, pagePathToDataPath, set, get} from './utils'
 
 import StateActions from './stateActions'
 
@@ -921,11 +921,8 @@ var PerAdminApp = {
 
     beforeStateAction(fun) {
         beforeStateActionImpl(fun)
-    },
-
-    getSanitizedNodeName(name) {
-        return sanitizeNodeName(name);
     }
+
 }
 
 export default PerAdminApp

--- a/admin-base/ui.apps/src/main/js/stateActions/createObject.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/createObject.js
@@ -24,7 +24,6 @@
  */
 import { LoggerFactory } from '../logger'
 import {SUFFIX_PARAM_SEPARATOR} from "../constants";
-import {sanitizeNodeName} from '../utils'
 let log = LoggerFactory.logger('createObject').setLevelDebug()
 
 export default function(me, target) {
@@ -33,7 +32,6 @@ export default function(me, target) {
     var api = me.getApi()
     return api.createObject(target.parent, target.name, target.template).then( () => {
         if(target.data) {
-            target.name = sanitizeNodeName(target.name);
             api.saveObjectEdit(target.parent + '/' + target.name, target.data).then( () => {
                 if(target.returnTo) {
                     me.loadContent(target.returnTo+'.html/path' +SUFFIX_PARAM_SEPARATOR + target.parent)

--- a/admin-base/ui.apps/src/main/js/stateActions/createPage.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/createPage.js
@@ -24,18 +24,14 @@
  */
 import { LoggerFactory } from '../logger'
 import {SUFFIX_PARAM_SEPARATOR} from "../constants";
-import {sanitizeNodeName} from '../utils'
 let log = LoggerFactory.logger('createPage').setLevelDebug()
 
 export default function(me, target) {
+
     log.fine(target)
     var api = me.getApi()
     api.createPage(target.parent, target.name, target.template).then( () => {
-        target.data.path = '/jcr:content';
-        // This has been persisted, so the node name may have changed from what we pass in.
-        // Probably would be better if this were read from the server response instead.
-        target.name = sanitizeNodeName(target.name);
-
+        target.data.path = '/jcr:content'
         api.savePageEdit(target.parent + '/' + target.name, target.data).then( () => {
             me.loadContent('/content/admin/pages.html/path' + SUFFIX_PARAM_SEPARATOR + target.parent)
         })

--- a/admin-base/ui.apps/src/main/js/utils.js
+++ b/admin-base/ui.apps/src/main/js/utils.js
@@ -135,23 +135,3 @@ export function stripNulls(data) {
         }
     }
 }
-
-export function sanitizeNodeName(name) {
-    // Here we String.prototype.normalize to normalize characters with diacritics to combined chars,
-    // then call replace with the correct Unicode block to remove those combining characters (i.e., ń -> n, Ä -> A)
-    // Lastly, any remaining characters that are not valid in URLs are removed
-    return name.normalize('NFD').replace(/[\u0300-\u036f]/g, "").replace(/[^0-9a-zA-Z-_]/g,"-");
-}
-
-
-// Per sling documentation, (https://sling.apache.org/documentation/the-sling-engine/request-parameters.html)
-// sling expects a _charset_ field in the formdata (not request header!), otherwise it will use the Servlet
-// standard of ISO-8859-1. Using this instead of standard FormData() will pre-set that form value
-export class UTF8FormData extends FormData {
-    // noinspection JSAnnotator
-    constructor() {
-        let fd = new FormData();
-        fd.append('_charset_', 'UTF-8');
-        return fd;
-    }
-}

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
@@ -1,7 +1,6 @@
 package com.peregrine.commons.util;
 
 import java.util.Locale;
-import java.util.regex.Pattern;
 
 /**
  * Commonly used Constants in Peregrine
@@ -87,7 +86,6 @@ public class PerConstants {
     public static final String VARIATIONS = "__variations";
     public static final String STATUS = "status";
     public static final String TEMPLATE_PATH = "templatePath";
-    public static final String DISPLAY_NAME = "displayName";
     public static final String SOURCE_PATH = "sourcePath";
     public static final String CREATED = "created";
     public static final String DELETED = "deleted";

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerUtil.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerUtil.java
@@ -543,16 +543,16 @@ public class PerUtil {
     /**
      * Check if the given resource has that Primary Type
      * @param resource Resource to be checked. It will test this resource and not go down to JCR Content
-     * @param primaryTypes Primary Types to test. If null or empty this method returns false
-     * @return true if the resource contains a Primary Type that matches one of the given values
+     * @param primaryType Primary Type to test. If null or empty this method returns false
+     * @return true if the resource contains a Primary Type that matches the given value
      */
-    public static boolean isPrimaryType(Resource resource, String... primaryTypes) {
-        String primaryResourceType = null;
+    public static boolean isPrimaryType(Resource resource, String primaryType) {
+        String answer = null;
         if(resource != null) {
             ValueMap properties = getProperties(resource, false);
-            primaryResourceType = properties.get(JCR_PRIMARY_TYPE, String.class);
+            answer = properties.get(JCR_PRIMARY_TYPE, String.class);
         }
-        return primaryResourceType != null && Arrays.asList(primaryTypes).contains(primaryResourceType);
+        return answer != null && answer.equals(primaryType);
     }
 
     /**


### PR DESCRIPTION
Reverts headwirecom/peregrine-cms#61

This PR appears to be causing this issue: https://github.com/headwirecom/peregrine-cms/issues/137

With fa3113e86faad6371a06351b427bb7fd05320cc5 checked out, pages created do not have drop targets. With the previous commit checked out, they do.