### PR TITLE
action now supports a visibility expression

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/models/ActionModel.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/models/ActionModel.java
@@ -193,4 +193,13 @@ public class ActionModel extends AbstractComponent {
     public String getClasses() {
       return classes;
       }
+
+      /* {"type":"string","source":"inject"} */
+    @Inject
+    private String visibility;
+
+    /* {"type":"string","source":"inject"} */
+    public String getVisibility() {
+      return visibility;
+      }
     }

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
@@ -23,7 +23,7 @@
   #L%
   -->   
 <template>
-    <span>
+    <span v-if="visible">
         <a 
             v-if                    = "!model.type"
             v-bind:href             = "targetHtml"
@@ -135,6 +135,13 @@
         },
         targetHtml() {
             return this.target !== '#' ? this.target + '.html' : '#'
+        },
+        visible() {
+            if(this.model.visibility) {
+                return exprEval.Parser.evaluate( this.model.visibility, $perAdminApp.getView() );
+            } else {
+                return true;
+            }
         }
     },
     methods: {

--- a/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/.content.xml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/.content.xml
@@ -47,9 +47,9 @@
                         sling:resourceType="admin/components/extensions"
                         id="admin.pages.subnav"/>
                 <addSite jcr:primaryType="nt:unstructured"
-                        sling:resourceType="admin/components/action" target="" type="icon" title="add site" command="addSite" icon="folder" classes="addSite"/>
+                        sling:resourceType="admin/components/action" target="" type="icon" title="add site" command="addSite" icon="folder" classes="addSite" visibility="state.tools.pages == '/content/sites'"/>
                 <addPage jcr:primaryType="nt:unstructured"
-                         sling:resourceType="admin/components/action" target="" type="icon" title="add page" command="addPage" icon="add" classes="addPage"/>
+                         sling:resourceType="admin/components/action" target="" type="icon" title="add page" command="addPage" icon="add" classes="addPage" visibility="state.tools.pages != '/content/sites'"/>
             </subnav>
         </nav>
 


### PR DESCRIPTION
@bkheadwire can you please review and see what e2e tests we break with this/fix them? It basically provides a different icon for creating a site vs creating a page in the page explorer and toggles the visibility based on the path