### PR TITLE
fix a bug where templates cant get access tags from multiple objects

### DIFF
--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -259,12 +259,12 @@ class PerAdminImpl {
                               }
                               for (let index in from) {
                                 data.model.fields[i].values = []
-                                let promise = axios.get(from).then(
+                                let promise = axios.get(from[index]).then(
                                     (response) => {
                                       for (var key in response.data) {
                                         if (response.data[key]['jcr:title']) {
                                           const nodeName = key
-                                          const val = from.replace(
+                                          const val = from[index].replace(
                                               '.infinity.json',
                                               '/' + nodeName)
                                           let name = response.data[key].name

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -254,23 +254,38 @@ class PerAdminImpl {
                         for(let i = 0; i < data.model.fields.length; i++) {
                             let from = data.model.fields[i].valuesFrom
                             if(from) {
+                              if (typeof from == "string") {
+                                from = {path: from}
+                              }
+                              for (let index in from) {
                                 data.model.fields[i].values = []
-                                let promise = axios.get(from).then( (response) => {
-                                    for(var key in response.data) {
-                                        if(response.data[key]['jcr:title']) {
-                                            const nodeName = key
-                                            const val = from.replace('.infinity.json', '/'+nodeName)
-                                            let name = response.data[key].name
-                                            if(!name) {
-                                                name = response.data[key]['jcr:title']
-                                            }
-                                            data.model.fields[i].values.push({ value: val, name: name })
+                                let promise = axios.get(from).then(
+                                    (response) => {
+                                      for (var key in response.data) {
+                                        if (response.data[key]['jcr:title']) {
+                                          const nodeName = key
+                                          const val = from.replace(
+                                              '.infinity.json',
+                                              '/' + nodeName)
+                                          let name = response.data[key].name
+                                          if (!name) {
+                                            name = response.data[key]['jcr:title']
+                                          }
+                                          data.model.fields[i].values.push(
+                                              {
+                                                value: val,
+                                                name: name
+                                              })
                                         }
-                                    }
-                                }).catch( (error) => {
-                                    logger.error('missing node', data.model.fields[i].valuesFrom, 'for list population in dialog', error)
+                                      }
+                                    }).catch((error) => {
+                                  logger.error('missing node',
+                                      data.model.fields[i].valuesFrom,
+                                      'for list population in dialog',
+                                      error)
                                 })
                                 promises.push(promise)
+                              }
                             }
                             let visible = data.model.fields[i].visible
                             if(visible) {


### PR DESCRIPTION
Templates can only access tags from a single source e.g.:
"valuesFrom": "/content/objects/blog/authors.infinity.json"

In this fix it is possible to pass multiple paths, so the template can accept tags from multiple sources e.g.:
"valuesFrom": [
"/content/objects/tags.infinity.json",
"/content/objects/tagstwo.infinity.json",
"/content/objects/tagsthree.infinity.json"
]