### PR TITLE
Issue 313 rename

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/ResourceRelocationService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/ResourceRelocationService.java
@@ -161,6 +161,7 @@ public class ResourceRelocationService
             String title = properties.get(JCR_TITLE, String.class);
             if(fromName.equals(title)) {
                 properties.put(JCR_TITLE, newName);
+                properties.put("name", newName);
             }
         }
         fromNode.getSession().move(fromPath, newPath);

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -334,7 +334,8 @@
         if (this.nodeType === NodeType.OBJECT){
           nodeName = this.node.path.split('/').slice(-1).pop()
         }
-        if (prompt(`new name for "${nodeName}"`)) {
+        let newName = prompt(`new name for "${nodeName}"`);
+        if (newName) {
           $perAdminApp.stateAction(`rename${this.uNodeType}`, {
             path: this.currentObject,
             name: newName


### PR DESCRIPTION
Here is a fix for [issue 313](https://github.com/headwirecom/peregrine-cms/issues/313) it makes two small fixes 

1. corrects the JS error which is looking for an undeclared variable
2. updates the name property which is used in addition to the node name
<img width="1434" alt="Screen Shot 2020-03-02 at 5 43 35 PM" src="https://user-images.githubusercontent.com/1811207/75725227-0370a400-5cae-11ea-8977-65962d913b5f.png">


Ideally, the rename operation would not use `prompt` and there would be vue modal pop up with a name and title, because it makes the most sense to edit these together. But there is a separate way to change the title, so I'm not undertaking that today.

