### PR TITLE
#415 nav menu for example site fixed

### DIFF
--- a/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/nav/template.vue
+++ b/samples/example-vue-site/ui.apps/src/main/content/jcr_root/apps/example/components/nav/template.vue
@@ -50,6 +50,11 @@
                 return this.$root.$data.page.siteRoot+'.html'
             }
         },
+        mounted: function() {
+          window.addEventListener('pageRendered', (e) => {
+              $('.collapse').collapse('hide');
+          }, false);
+        },
         methods: {
             isActive: function(item) {
                 return item.path === this.$root.$data.page.pagePath ? 'active': ''


### PR DESCRIPTION
 example site nav menu now closes when new page is loaded, doesn't open
 Solves issue: #415 
Tested links in nav ✅ 
Tested links on pages ✅ 
Regression tested ✅ 
To test: #1 open example site
#2 go to mobile mode (either with browser tool or shorten width of window) 
#3 check to see that menu closes when selecting a page in the nav