### PR TITLE
feature/canonicalurl

### DIFF
--- a/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
+++ b/pagerenderer/vue/core/src/main/java/com/peregrine/pagerender/vue/models/PageModel.java
@@ -408,6 +408,14 @@ public class PageModel extends Container {
         return absOgImagePath;
     }
 
+    public String getCanonicalUrl() {
+        final String primaryDomain = getPrimaryDomain();
+
+        return StringUtils.isNotBlank(primaryDomain)
+                ? getPrimaryDomain() + getPagePath().replace(getSiteRoot(), "") + ".html"
+                : getPagePath() + ".html";
+    }
+
     class Tag {
         private String path;
         private String name;

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/explorer_dialog.json
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/explorer_dialog.json
@@ -185,5 +185,13 @@
       { "name": "1.0", "value": "1.0" }
     ],
     "hint": "The priority of this URL relative to other URLs on your site. Valid values range from 0.0 to 1.0. This value does not affect how your pages are compared to pages on other sites—it only lets the search engines know which pages you deem most important for the crawlers."
+  },
+  {
+    "type": "material-textarea",
+    "inputType": "text",
+    "model": "jsonld",
+    "label": "JSON-LD",
+    "placeholder": "JSON-LD object",
+    "rows": 10
   }
 ]}

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -23,6 +23,9 @@
 
     <link rel="manifest" href="${helper.siteRootPath}/manifest.json">
     <script>$peregrineSiteRoot = "${helper.siteRootPath @ context='unsafe'}"</script>
+    <script data-sly-test="${resource.jsonld}" type="application/ld+json">
+        ${resource.jsonld @ context = 'unsafe'}
+    </script>
 
     <sly data-sly-include="tracker-head.html"></sly>
 

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -24,9 +24,7 @@
 
     <link rel="manifest" href="${helper.siteRootPath}/manifest.json">
     <script>$peregrineSiteRoot = "${helper.siteRootPath @ context='unsafe'}"</script>
-    <script data-sly-test="${resource.jsonld}" type="application/ld+json">
-        ${resource.jsonld @ context = 'unsafe'}
-    </script>
+    <script data-sly-test="${resource.jsonld}" type="application/ld+json">${resource.jsonld @ context = 'unsafe'} </script>
 
     <sly data-sly-include="tracker-head.html"></sly>
 

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -19,6 +19,7 @@
     <meta data-sly-test="${resource.ogUrl}" property="og:url" content="${resource.ogUrl}"/>
 
     <title>${resource.jcr:title} | ${helper.model.brand}</title>
+    <link rel="canonical" href="${helper.model.canonicalUrl}"/>
     <sly data-sly-list="${helper.model.prefetchDNS}"><link rel="dns-prefetch" href="${item}"></sly>
 
     <link rel="manifest" href="${helper.siteRootPath}/manifest.json">

--- a/pagerenderer/vue/ui.apps/src/main/js/peregrineApp.js
+++ b/pagerenderer/vue/ui.apps/src/main/js/peregrineApp.js
@@ -242,8 +242,8 @@ function processLoadedContent(data, path, firstTime, fromPopState) {
             log.fine("PUSHSTATE : " + path);
             document.title = getPerView().page.title + ' | ' + getPerView().page.brand  
 
-            let canonical = document.querySelector('link[rel="canonical"]')
-            if(canonical !== null) canonical.href = getPerView().page.canonicalUrl
+            var canonical = document.querySelector('link[rel="canonical"]')
+            if(canonical) canonical.href = getPerView().page.canonicalUrl
 
             var url = document.location.href
             var domains = (getPerView().page.domains)

--- a/pagerenderer/vue/ui.apps/src/main/js/peregrineApp.js
+++ b/pagerenderer/vue/ui.apps/src/main/js/peregrineApp.js
@@ -241,6 +241,10 @@ function processLoadedContent(data, path, firstTime, fromPopState) {
         if(document.location !== path && !fromPopState) {
             log.fine("PUSHSTATE : " + path);
             document.title = getPerView().page.title + ' | ' + getPerView().page.brand  
+
+            let canonical = document.querySelector('link[rel="canonical"]')
+            if(canonical !== null) canonical.href = getPerView().page.canonicalUrl
+
             var url = document.location.href
             var domains = (getPerView().page.domains)
             var newLocation = path


### PR DESCRIPTION
This feature introduces support for canonical URLs.

There are two primary use cases:
1. No public domain set (default) - Relative URL is used.

2. Public domain set under site settings - Absolute URL is used with the site root path removed (i.e. short URL). This assumes the application is fronted by the Apache HTTPD server with rules for shortening the URL.

*Other Notes:*
1. The client-side code has been updated to update the `href` value  in `<link rel="canonical">`  during site navigation.