### PR TITLE
#487 fixed the browser interpretation of styles priority

### DIFF
--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/page.html
@@ -5,7 +5,7 @@
 
     <sly data-sly-list="${helper.model.prefetchDNS}"><link rel="preconnect" href="${item}"><link rel="dns-prefetch" href="${item}"></sly>
     <sly data-sly-list="${helper.model.siteJS}"><link rel="preload" href="${item}" as="script"></sly>
-    <sly data-sly-list="${helper.model.siteCSS}"><link rel="preload" href="${item}" as="style"></sly>
+    <sly data-sly-list="${helper.model.siteCSS}"><link rel="preload" href="${item}" as="style" onload="this.rel='stylesheet'" type="text/css"></sly>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#c0c0c0">
@@ -67,8 +67,6 @@
 </sly>
 
 <sly data-sly-include="renderer.html"></sly>
-
-<sly data-sly-list="${helper.model.siteCSS}"><link rel="stylesheet" href="${item}" type="text/css"></sly>
 
 <script>
     var $perView = { view: 'preview' };


### PR DESCRIPTION
Resolves issue: #487 

Stylesheets still preload, but now vue component styles will be placed after stylesheets in the html document. 

To test:
1. Drop multinavigation component on a page
2. give the component a root path of `/content/${your-site}/pages`
3. component should work normally as far as hovering the links