### PR TITLE
feature/pagespeed

### DIFF
--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
@@ -172,7 +172,7 @@ public class ModPageSpeedCacheInvalidationService
                 for (String domain: domains)
                 {
                     // construct site-wide pagespeed invalidation request URL
-                    siteInvalidationUls.add(domain + "/*");
+                    siteInvalidationUls.add(domain + "/pagespeed_admin/cache?purge=*");
                 }
 
             }

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
@@ -106,11 +106,6 @@ public class ModPageSpeedCacheInvalidationService
 
         cacheInvalidationUrl = configuration.cacheInvalidationUrl();
 
-        if(StringUtils.isBlank(cacheInvalidationUrl))
-        {
-            throw new IllegalArgumentException("Invalid PageSpeed cache invalidation URL: " + cacheInvalidationUrl);
-        }
-
         log.trace("PageSpeed Invalidation Service Name: '{}' created", getName());
         log.trace("PageSpeed cache invalidation URL: '{}'", cacheInvalidationUrl);
     }
@@ -232,18 +227,6 @@ public class ModPageSpeedCacheInvalidationService
         }
 
         return domains;
-    }
-
-    /**
-     * Formats a JCR path as suitable mod_pagespeed cache key.
-     *
-     * @param path the JCR path to format.
-     *
-     * @return An absolute URL for the cache invalidation request on success, and <code>null</code> otherwise.
-     */
-    protected String formatCacheKeyRequest(final String path)
-    {
-        return cacheInvalidationUrl + "/*";
     }
 
     /**

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
@@ -140,9 +140,18 @@ public class ModPageSpeedCacheInvalidationService
     @Override
     public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException
     {
-        for (String siteInvalidationUrl: getSitesInvalidationUrls(resourceList))
+        if (StringUtils.isNotBlank(cacheInvalidationUrl))
         {
-            invalidateCacheKey(siteInvalidationUrl);
+            // If an invalidation URL is specified in the OSGi config, use that URL for invalidation. This will
+            // preserve backwards compatibility.
+            invalidateCacheKey(cacheInvalidationUrl);
+        } else {
+            // If an invalidation URL is not specified in the OSGi config, attempt to lookup all the domains
+            // associated with the replicated node/site.
+            for (String siteInvalidationUrl : getSitesInvalidationUrls(resourceList))
+            {
+                invalidateCacheKey(siteInvalidationUrl);
+            }
         }
 
         return Collections.emptyList();


### PR DESCRIPTION
@reusr1, There was quite a bit required to make the PageSpeed Cache invalidation work correctly with multi-tenancy. Here are the high-level changes:
1. The backend interface changed at some point and the `replicate()` method was no longer invoked. We are not correctly calling the correct `replicate()` method.
2. The implementation has shifted from single URL invalidation, to invalidating the entire named virtual host. This is required since mod_pagespeed only supports single URLs or entire invalidation for a given site. If we wanted to use invalidation by key, we would have to consult each reference and issue "N" requests to purge each key.
3. Legacy invalidation endpoint is preserved for backwards compatibility. If the endpoint is left empty in the OSGi configuration, the replication paths will be parsed to determine the list of unique tenant sites to invalidate. For each unique tenant, the list of public-facing domains are then looked up and used to construct 0 or more cache invalidation URLs.
4. I had to update the HTTP client to use a "PURGE" method instead of a "GET".