### PR TITLE
Implemented: Added support to localize content in JSON response using experiences

### DIFF
--- a/platform/base/core/src/main/java/com/peregrine/nodetypes/merge/PageMerge.java
+++ b/platform/base/core/src/main/java/com/peregrine/nodetypes/merge/PageMerge.java
@@ -171,8 +171,11 @@ public class PageMerge implements Use {
             if(val instanceof Map) {
                 Map map = (Map) val;
 
-                // Localize content using experiences.
-                localizeContent(map);
+                String xPerExperiences = request.getHeader("x-per-experiences");
+                if (!"off".equalsIgnoreCase(xPerExperiences)) {
+                    // Localize content using experiences.
+                    localizeContent(map);
+                }
 
                 String path = (String) map.get(PATH);
                 if(path != null) {

--- a/platform/base/core/src/main/java/com/peregrine/nodetypes/merge/PageMerge.java
+++ b/platform/base/core/src/main/java/com/peregrine/nodetypes/merge/PageMerge.java
@@ -13,9 +13,9 @@ package com.peregrine.nodetypes.merge;
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,10 +36,13 @@ import static java.util.regex.Pattern.compile;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import javax.script.Bindings;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -167,6 +170,10 @@ public class PageMerge implements Use {
             boolean merged = false;
             if(val instanceof Map) {
                 Map map = (Map) val;
+
+                // Localize content using experiences.
+                localizeContent(map);
+
                 String path = (String) map.get(PATH);
                 if(path != null) {
                     log.debug("find entry for {}", path);
@@ -186,6 +193,86 @@ public class PageMerge implements Use {
                 target.add(val);
             }
         }
+    }
+
+    private void localizeContent(Map map) {
+        /*
+            Sample node structure, with localization experiences:
+            {
+              "jcr:lastModified": "{Date}2020-09-08 16:20:33",
+              "jcr:lastModifiedBy": "admin",
+              "jcr:primaryType": "{Name}nt:unstructured",
+              "sling:resourceType": "themeclean/components/multilang",
+              "text": "This is text",
+              "title": "This is title",
+              "experiences": {
+                "jcr:primaryType": "{Name}nt:unstructured",
+                "de": {
+                  "experiences": [
+                    "lang:de"
+                  ],
+                  "jcr:primaryType": "{Name}nt:unstructured",
+                  "text": "Das ist Text",
+                  "title": "Das ist Titel"
+                },
+                "fr": {
+                  "experiences": [
+                    "lang:fr"
+                  ],
+                  "jcr:primaryType": "{Name}nt:unstructured",
+                  "text": "C\u0027est du texte",
+                  "title": "C\u0027est le titre"
+                }
+              }
+            }
+        */
+
+        String localeLanguage = "";
+        try {
+            localeLanguage = request.getLocale().getLanguage();
+        } catch(UnsupportedOperationException e) {
+            log.error("Failed to fetch the request locale.", e);
+        }
+        Map localizedContent = getLocalizedContent((ArrayList) map.get("experiences"), localeLanguage);
+
+        // Replacing the node properties with localized one.
+        ArrayList<String> excludedProperties = new ArrayList<String>(Arrays.asList("name", "path", "component", "jcr:primaryType", "experiences"));
+        Set localizeContentSet = localizedContent.entrySet();
+        Iterator localizeContentIterator = localizeContentSet.iterator();
+        while (localizeContentIterator.hasNext()) {
+            Map.Entry localizeContentMap = (Map.Entry) localizeContentIterator.next();
+            if (!excludedProperties.contains(localizeContentMap.getKey())) {
+                map.put(localizeContentMap.getKey(), localizeContentMap.getValue());
+            }
+        }
+    }
+
+    private Map getLocalizedContent(ArrayList experiencesNode, String localeLanguage) {
+        Map localizedContent = new LinkedHashMap();
+        if (experiencesNode != null) {
+            for (int index = 0; index < experiencesNode.size(); index++) {
+                LinkedHashMap experience = (LinkedHashMap) experiencesNode.get(index);
+                /*
+                    Sample French language experience node:
+                    {
+                      "experiences": [
+                        "lang:fr"
+                      ],
+                      "jcr:primaryType": "{Name}nt:unstructured",
+                      "text": "C\u0027est du texte",
+                      "title": "C\u0027est le titre"
+                    }
+                 */
+
+                ArrayList experiences = (ArrayList) experience.get("experiences");
+                Boolean isEqualsToRequestLocale = experiences.contains("lang:" + localeLanguage);
+                if (isEqualsToRequestLocale) {
+                    localizedContent = experience;
+                    break;
+                }
+            }
+        }
+        return localizedContent;
     }
 
     private String toJSON(Map template) {


### PR DESCRIPTION
A detailed explanation of the code and feature is available in this video.
https://youtu.be/KfDAPrCSgGs

Each node can manage the 'experiences' child node containing the language-specific localize node. Based on this return the localize content in JSON.
Please refer to the code for the sample node structure.

Thanks: @reusr1  for the inputs.