### PR TITLE
Replicate referenced assets

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/resource/ReferenceListerService.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/resource/ReferenceListerService.java
@@ -30,16 +30,17 @@ import static com.peregrine.commons.util.PerConstants.SLASH;
 import static com.peregrine.commons.util.PerUtil.isEmpty;
 import static com.peregrine.commons.util.PerUtil.isNotEmpty;
 import static com.peregrine.commons.util.PerUtil.listMissingParents;
+import static java.util.Objects.isNull;
 
+import com.google.common.collect.Lists;
 import com.peregrine.commons.util.PerUtil.MissingOrOutdatedResourceChecker;
 import com.peregrine.replication.Reference;
 import com.peregrine.replication.ReferenceLister;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+
+import java.util.*;
+
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -103,16 +104,18 @@ public class ReferenceListerService
     }
 
     @Override
-    public List<Reference> getReferencedByList(Resource resource) {
-        List<Reference> answer = new ArrayList<>();
-        if(resource != null) {
-            for(String root : referencedByRootList) {
-                Resource rootResource = resource != null ? resource.getResourceResolver().getResource(root) : null;
-                if(rootResource != null) {
-                    traverseTreeReverse(rootResource, resource.getPath(), answer);
-                }
-            }
+    public List<Reference> getReferencedByList(final Resource resource) {
+        if (isNull(resource)) {
+            return Collections.emptyList();
         }
+
+        final List<Reference> answer = new ArrayList<>();
+        final ResourceResolver resourceResolver = resource.getResourceResolver();
+        final String path = resource.getPath();
+        referencedByRootList.stream()
+                .map(resourceResolver::getResource)
+                .filter(Objects::nonNull)
+                .forEach(r -> traverseTreeReverse(r, path, answer));
         return answer;
     }
 

--- a/platform/base/core/src/main/java/com/peregrine/replication/Replication.java
+++ b/platform/base/core/src/main/java/com/peregrine/replication/Replication.java
@@ -27,6 +27,7 @@ package com.peregrine.replication;
 
 import org.apache.sling.api.resource.Resource;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -79,7 +80,7 @@ public interface Replication {
      *
      * @throws ReplicationException If the replication failed
      */
-    List<Resource> replicate(List<Resource> resourceList)
+    List<Resource> replicate(Collection<Resource> resourceList)
         throws ReplicationException;
 
     class ReplicationException

--- a/platform/commons/src/main/java/com/peregrine/commons/ResourceUtils.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/ResourceUtils.java
@@ -6,8 +6,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import static com.peregrine.commons.Strings.COLON;
 import static com.peregrine.commons.Strings._SCORE;
@@ -99,4 +98,17 @@ public final class ResourceUtils {
                 && !ResourceUtil.isSyntheticResource(resource);
     }
 
+    public static <L extends List<Resource>> L removeDuplicates(final L list) {
+        final Set<String> paths = new HashSet<>();
+        for (int i = 0; i < list.size(); i++) {
+            final String path = list.get(i).getPath();
+            if (paths.contains(path)) {
+                list.remove(i--);
+            } else {
+                paths.add(path);
+            }
+        }
+
+        return list;
+    }
 }

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
@@ -20,11 +20,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import static com.peregrine.commons.util.PerUtil.isEmpty;
@@ -171,12 +167,12 @@ public class DefaultReplicationMapperService
     }
 
     @Override
-    public List<Resource> deactivate(Resource source) throws ReplicationException {
+    public List<Resource> deactivate(Resource source) {
         return null;
     }
 
     @Override
-    public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException {
+    public List<Resource> replicate(Collection<Resource> resourceList) throws ReplicationException {
         List<Resource> answer = new ArrayList<>();
         Map<DefaultReplicationConfig, List<Resource>> resourceByReplication = new HashMap<>();
         resourceByReplication.put(defaultMapping, new ArrayList<Resource>());

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
@@ -158,11 +158,11 @@ public class DefaultReplicationMapperService
     @Override
     public List<Resource> replicate(Resource source, boolean deep) throws ReplicationException {
         logger.trace("Starting Resource: '{}'", source.getPath());
-        List<Resource> referenceList = referenceLister.getReferenceList(true, source, true);
+        final List<Resource> referenceList = referenceLister.getReferenceList(true, source, deep);
         logger.trace("Reference List: '{}'", referenceList);
-        List<Resource> replicationList = new ArrayList<>();
+        final Set<Resource> replicationList = listMissingResources(source, new HashSet<>(), new AddAllResourceChecker(), deep);
         replicationList.add(source);
-        listMissingResources(source, replicationList, new AddAllResourceChecker(), deep);
+        replicationList.addAll(referenceList);
         return replicate(replicationList);
     }
 

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
@@ -1,19 +1,10 @@
 package com.peregrine.admin.replication;
 
-import com.peregrine.commons.util.PerUtil.AddAllResourceChecker;
 import com.peregrine.replication.ReferenceLister;
 import com.peregrine.replication.Replication;
 import org.apache.sling.api.resource.Resource;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.ComponentContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.*;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -23,9 +14,7 @@ import org.slf4j.LoggerFactory;
 import java.util.*;
 import java.util.Map.Entry;
 
-import static com.peregrine.commons.util.PerUtil.isEmpty;
-import static com.peregrine.commons.util.PerUtil.listMissingResources;
-import static com.peregrine.commons.util.PerUtil.splitIntoParameterMap;
+import static com.peregrine.commons.util.PerUtil.*;
 
 /**
  * This class provides the implementation of the Default Replication Mapper

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
@@ -1,5 +1,6 @@
 package com.peregrine.admin.replication;
 
+import com.peregrine.commons.ResourceUtils;
 import com.peregrine.replication.ReferenceLister;
 import com.peregrine.replication.Replication;
 import org.apache.sling.api.resource.Resource;
@@ -152,6 +153,7 @@ public class DefaultReplicationMapperService
         final List<Resource> replicationList = listMissingResources(source, new ArrayList<>(), new AddAllResourceChecker(), deep);
         replicationList.add(0, source);
         replicationList.addAll(0, referenceList);
+        ResourceUtils.removeDuplicates(replicationList);
         return replicate(replicationList);
     }
 

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/DefaultReplicationMapperService.java
@@ -160,9 +160,9 @@ public class DefaultReplicationMapperService
         logger.trace("Starting Resource: '{}'", source.getPath());
         final List<Resource> referenceList = referenceLister.getReferenceList(true, source, deep);
         logger.trace("Reference List: '{}'", referenceList);
-        final Set<Resource> replicationList = listMissingResources(source, new HashSet<>(), new AddAllResourceChecker(), deep);
-        replicationList.add(source);
-        replicationList.addAll(referenceList);
+        final List<Resource> replicationList = listMissingResources(source, new ArrayList<>(), new AddAllResourceChecker(), deep);
+        replicationList.add(0, source);
+        replicationList.addAll(0, referenceList);
         return replicate(replicationList);
     }
 

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/BaseFileReplicationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/BaseFileReplicationService.java
@@ -40,6 +40,7 @@ import javax.jcr.Session;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -117,7 +118,7 @@ public abstract class BaseFileReplicationService
     }
 
     @Override
-    public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException {
+    public List<Resource> replicate(Collection<Resource> resourceList) throws ReplicationException {
         List<Resource> answer = new ArrayList<>();
         log.trace("Replicate Resource List: '{}'", resourceList);
         // Replicate the resources

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/BaseFileReplicationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/BaseFileReplicationService.java
@@ -31,6 +31,7 @@ import com.peregrine.commons.util.PerUtil;
 import com.peregrine.commons.util.PerUtil.ResourceChecker;
 import com.peregrine.render.RenderService;
 import com.peregrine.render.RenderService.RenderException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 
@@ -100,7 +101,7 @@ public abstract class BaseFileReplicationService
             }
         }
         // This only returns the referenced resources. Now we need to check if there are any JCR Content nodes to be added as well
-        for(Resource reference: new ArrayList<Resource>(replicationList)) {
+        for(Resource reference: replicationList) {
             PerUtil.listMissingResources(reference, replicationList, resourceChecker, false);
         }
         PerUtil.listMissingResources(startingResource, replicationList, resourceChecker, deep);
@@ -331,11 +332,11 @@ public abstract class BaseFileReplicationService
 
     public static class ExportExtension {
         private String name;
-        private List<String> types = new ArrayList<>();
+        private List<String> types;
         private boolean exportFolders = false;
 
         public ExportExtension(String name, List<String> types) {
-            if(PerUtil.isEmpty(name)) {
+            if(StringUtils.isEmpty(name)) {
                 throw new IllegalArgumentException(EXTENSION_NAME_MUST_BE_PROVIDED);
             }
             if(types == null || types.isEmpty()) {

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/DistributionReplicationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/DistributionReplicationService.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static com.peregrine.admin.replication.ReplicationUtil.updateReplicationProperties;
@@ -173,15 +174,15 @@ public class DistributionReplicationService
     }
 
     @Override
-    public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException {
+    public List<Resource> replicate(Collection<Resource> resourceList) throws ReplicationException {
         return replicate(resourceList, true);
     }
 
-    public List<Resource> deactivate(List<Resource> resourceList) throws ReplicationException {
+    public List<Resource> deactivate(Collection<Resource> resourceList) throws ReplicationException {
         return replicate(resourceList, false);
     }
 
-    public List<Resource> replicate(List<Resource> resourceList, boolean activate) throws ReplicationException {
+    public List<Resource> replicate(Collection<Resource> resourceList, boolean activate) throws ReplicationException {
         List<Resource> answer = new ArrayList<>();
         if(distributor != null) {
             ResourceResolver resourceResolver = null;

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/LocalFileSystemReplicationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/LocalFileSystemReplicationService.java
@@ -25,23 +25,18 @@ package com.peregrine.admin.replication.impl;
  * #L%
  */
 
+import com.peregrine.render.RenderService;
 import com.peregrine.replication.ReferenceLister;
 import com.peregrine.replication.Replication;
-import com.peregrine.render.RenderService;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.osgi.framework.BundleContext;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Modified;
-import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.*;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -52,10 +47,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
-import static com.peregrine.commons.util.PerUtil.intoList;
-import static com.peregrine.commons.util.PerUtil.isNotEmpty;
-import static com.peregrine.commons.util.PerUtil.splitIntoMap;
-import static com.peregrine.commons.util.PerUtil.splitIntoProperties;
+import static com.peregrine.commons.util.PerUtil.*;
+import static java.util.Objects.isNull;
 
 /**
  * This class replicates resources to a local file system folder
@@ -302,37 +295,34 @@ public class LocalFileSystemReplicationService
     @Override
     void removeReplica(Resource resource, final List<Pattern> namePattern, final boolean isFolder) throws ReplicationException {
         final String resourceName = resource.getName();
-        File directory = new File(targetFolder, resource.getParent().getPath());
+        final File directory = new File(targetFolder, resource.getParent().getPath());
         if(!directory.exists() || !directory.isDirectory()) {
             throw new ReplicationException(String.format(FAILED_STORE_RENDERING_MISSING_PARENT_FOLDER, directory.getAbsolutePath()));
         }
-        final List<Pattern> patterns = new ArrayList<>();
-        File[] filesToBeDeletedFiles = directory.listFiles(
-            new FileFilter() {
-                @Override
-                public boolean accept(File file) {
-                    if(isFolder) {
-                        if(file.isDirectory() && file.getName().equals(resourceName)) {
+
+        final File[] filesToBeDeletedFiles = directory.listFiles(
+                file -> {
+                    if (isFolder && file.isDirectory() && file.getName().equals(resourceName)) {
+                        return true;
+                    }
+
+                    if (isNull(namePattern)) {
+                        return file.getName().startsWith(resourceName);
+                    }
+
+                    for (final Pattern pattern : namePattern) {
+                        if (pattern.matcher(file.getName()).matches()) {
                             return true;
                         }
                     }
-                    if(namePattern == null) {
-                        return file.getName().startsWith(resourceName);
-                    } else {
-                        for(Pattern pattern : namePattern) {
-                            if(pattern.matcher(file.getName()).matches()) {
-                                return true;
-                            }
-                        }
-                    }
+
                     return false;
                 }
-            }
         );
         if(filesToBeDeletedFiles != null) {
             for(File toBeDeleted : filesToBeDeletedFiles) {
                 log.trace("Delete File: '{}'", toBeDeleted.getAbsolutePath());
-                if(!deleteFile(toBeDeleted)) {
+                if (!deleteFile(toBeDeleted)) {
                     throw new ReplicationException(String.format(FAILED_TO_DELETE_FILE, toBeDeleted.getAbsolutePath()));
                 }
 

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/LocalReplicationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/LocalReplicationService.java
@@ -48,11 +48,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.peregrine.admin.replication.ReplicationUtil.updateReplicationProperties;
 import static com.peregrine.commons.util.PerConstants.JCR_UUID;
@@ -211,7 +207,7 @@ public class LocalReplicationService
     }
 
     @Override
-    public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException {
+    public List<Resource> replicate(Collection<Resource> resourceList) throws ReplicationException {
         List<Resource> handledSources = new ArrayList<>();
         List<Resource> answer = new ArrayList<>();
         // Replicate the resources

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/impl/ModPageSpeedCacheInvalidationService.java
@@ -46,10 +46,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -134,7 +131,7 @@ public class ModPageSpeedCacheInvalidationService
     }
 
     @Override
-    public List<Resource> replicate(List<Resource> resourceList) throws ReplicationException
+    public List<Resource> replicate(Collection<Resource> resourceList) throws ReplicationException
     {
         if (StringUtils.isNotBlank(cacheInvalidationUrl))
         {
@@ -153,7 +150,7 @@ public class ModPageSpeedCacheInvalidationService
         return Collections.emptyList();
     }
 
-    private Set<String> getSitesInvalidationUrls(final List<Resource> resources)
+    private Set<String> getSitesInvalidationUrls(final Collection<Resource> resources)
     {
         Set<String> siteInvalidationUls = new HashSet<>();
         Set<String> sites = new HashSet<String>();

--- a/platform/replication/core/src/main/java/com/peregrine/admin/replication/servlet/TenantSetupReplicationServlet.java
+++ b/platform/replication/core/src/main/java/com/peregrine/admin/replication/servlet/TenantSetupReplicationServlet.java
@@ -53,6 +53,7 @@ import static com.peregrine.commons.util.PerUtil.EQUALS;
 import static com.peregrine.commons.util.PerUtil.PER_PREFIX;
 import static com.peregrine.commons.util.PerUtil.PER_VENDOR;
 import static com.peregrine.commons.util.PerUtil.POST;
+import static java.util.Objects.isNull;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_METHODS;
 import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES;
@@ -96,19 +97,17 @@ public class TenantSetupReplicationServlet extends AbstractBaseServlet {
 
     @Override
     protected Response handleRequest(Request request) throws IOException {
-        JsonResponse answer = null;
         logger.trace("Request Path: '{}'", request.getRequestPath());
         logger.trace("Request URI: '{}'", request.getRequest().getRequestURI());
         logger.trace("Request URL: '{}'", request.getRequest().getRequestURL());
-        String sourcePath = request.getParameter(PATH);
 //        String replicationName = request.getPa
 //        if(replicationName == null || replicationName.isEmpty()) {
 //            return new ErrorResponse()
 //                .setHttpErrorCode(SC_BAD_REQUEST)
 //                .setErrorMessage(PARAMETER_NAME_FOR_THE_REPLICATION_NAME_IS_NOT_PROVIDED);
 //        }
-        String withSiteParameter = request.getParameter(WITH_SITE);
-        boolean withSite = withSiteParameter != null && Boolean.TRUE.toString().equals(withSiteParameter.toLowerCase());
+//        String withSiteParameter = request.getParameter(WITH_SITE);
+//        boolean withSite = withSiteParameter != null && Boolean.TRUE.toString().equals(withSiteParameter.toLowerCase());
 //        String deactivateParameter = request.getParameter(DEACTIVATE);
 //        boolean deactivate = deactivateParameter != null && Boolean.TRUE.toString().equals(deactivateParameter.toLowerCase());
 //        Replication replication = replications.get(replicationName);
@@ -117,63 +116,64 @@ public class TenantSetupReplicationServlet extends AbstractBaseServlet {
 //                .setHttpErrorCode(SC_BAD_REQUEST)
 //                .setErrorMessage(REPLICATION_NOT_FOUND_FOR_NAME + replicationName);
 //        }
+        String sourcePath = request.getParameter(PATH);
         Resource source = request.getResourceResolver().getResource(sourcePath);
-        if(source != null) {
-            // Make sure that the Resource is a Site
-            if(!source.getResourceType().equals(SITE_PRIMARY_TYPE)) {
-                return new ErrorResponse()
+        if (isNull(source)) {
+            return new ErrorResponse()
+                    .setHttpErrorCode(SC_BAD_REQUEST)
+                    .setErrorMessage(String.format(SUFFIX_IS_NOT_RESOURCE, sourcePath));
+        }
+
+        // Make sure that the Resource is a Site
+        if (!SITE_PRIMARY_TYPE.equals(source.getResourceType())) {
+            return new ErrorResponse()
                     .setHttpErrorCode(SC_BAD_REQUEST)
                     .setErrorMessage(String.format(SUFFIX_IS_NOT_SITE, sourcePath));
-            }
-            List<Resource> replicationList = new ArrayList<>();
-            // Thinks to search for
-            // - /content/<site>/pages/css
-            // - /etc/felibs/<theme>.css / .js
-            // - /etc/felibs/<site>.css / .js
-            // - /etc/felibs/<theme dependencies>.css / .js
+        }
+        List<Resource> replicationList = new ArrayList<>();
+        // Thinks to search for
+        // - /content/<site>/pages/css
+        // - /etc/felibs/<theme>.css / .js
+        // - /etc/felibs/<site>.css / .js
+        // - /etc/felibs/<theme dependencies>.css / .js
 //            if(withSite) {
-                replicationList.add(source);
+        replicationList.add(source);
 //            } else {
 //                Resource css = source.getChild("pages/css");
 //                if (css != null) {
 //                    replicationList.add(css);
 //                }
 //            }
-            Resource felibs = request.getResourceResolver().getResource(FELIBS_ROOT);
-            handleSourceSites(source, replicationList, felibs);
-            logger.info("List of Resource to be replicated: '{}'", replicationList);
-            List<Resource> allReplicatedResource = new ArrayList<>();
-            for(Resource resource: replicationList) {
-                try {
-                    logger.info("Replication Resource: '{}'", resource);
-                    List<Resource> replicatedItems = defaultReplicationMapper.replicate(resource, true);
-                    allReplicatedResource.addAll(replicatedItems);
-                } catch (ReplicationException e) {
-                    logger.warn("Replication Failed", e);
-                    return new ErrorResponse()
+        final Resource felibs = request.getResourceResolver().getResource(FELIBS_ROOT);
+        handleSourceSites(source, replicationList, felibs);
+        logger.info("List of Resource to be replicated: '{}'", replicationList);
+        final List<Resource> allReplicatedResource = new ArrayList<>();
+        for (final Resource resource : replicationList) {
+            try {
+                logger.info("Replication Resource: '{}'", resource);
+                List<Resource> replicatedItems = defaultReplicationMapper.replicate(resource, true);
+                allReplicatedResource.addAll(replicatedItems);
+            } catch (ReplicationException e) {
+                logger.warn("Replication Failed", e);
+                return new ErrorResponse()
                         .setHttpErrorCode(SC_BAD_REQUEST)
                         .setErrorMessage(REPLICATION_FAILED)
                         .setException(e);
-                }
             }
-            answer = new JsonResponse();
-            answer.writeAttribute(SOURCE_NAME, source.getName());
-            answer.writeAttribute(SOURCE_PATH, source.getPath());
-            answer.writeArray(REPLICATES);
-            if(allReplicatedResource != null) {
-                for(Resource child : allReplicatedResource) {
-                    answer.writeObject();
-                    answer.writeAttribute(NAME, child.getName());
-                    answer.writeAttribute(PATH, child.getPath());
-                    answer.writeClose();
-                }
-            }
-            answer.writeClose();
-        } else {
-            return new ErrorResponse()
-                .setHttpErrorCode(SC_BAD_REQUEST)
-                .setErrorMessage(String.format(SUFFIX_IS_NOT_RESOURCE, sourcePath));
         }
+
+        final JsonResponse answer = new JsonResponse();
+        answer.writeAttribute(SOURCE_NAME, source.getName());
+        answer.writeAttribute(SOURCE_PATH, source.getPath());
+        answer.writeArray(REPLICATES);
+        for (final Resource child : allReplicatedResource) {
+            answer.writeObject();
+            answer.writeAttribute(NAME, child.getName());
+            answer.writeAttribute(PATH, child.getPath());
+            answer.writeClose();
+        }
+
+        answer.writeClose();
         return answer;
     }
 


### PR DESCRIPTION
The core solution is what changed in `com.peregrine.admin.replication.DefaultReplicationMapperService#replicate(org.apache.sling.api.resource.Resource, boolean)`. I'm pretty sure this must have been the only bug that caused all the referenced replication missing.

The rest is [boy scout](https://deviq.com/boy-scout-rule/) stuff. Feel free to dismiss it, I'd prepare a separate branch if needed.

The simplest case is covered. There are more advanced things not included. E.g. if one includes an image inside a rich text component within `<img src="..."`. But as we talked - [this ticket](https://github.com/headwirecom/peregrine-cms/issues/545) is for the direct references only.