### PR TITLE
Allow read on index.html for all_tenants

### DIFF
--- a/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
+++ b/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
@@ -75,6 +75,7 @@ scripts=[\
 # set ACL's for eveall_tenants group on paths lower than root 
 # Note: this replaces jcr:read for everyone on root
     set ACL for all_tenants
+        allow jcr:read on /index.html
         allow jcr:read on /perapi/admin
         allow jcr:read on /apps
         allow jcr:read on /i18n


### PR DESCRIPTION
I was also wondering whether an alternative solution could be to set `sling:redirect` on `jcr:root` just as the `index.html`'s `js` does, but for now let's leave it as is. Unless you guys prefer the above - then just let me know.
Anyways - this will not work on a fresh instance right away, a restart is needed. I assume this is another issue to be handled separately (`org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config` seems to kick in only after 2+ instance start) - when fixed, it will propagate here as well.