### PR TITLE
Sling12/inline edit issues

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/pages/edit/.content.xml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/pages/edit/.content.xml
@@ -37,7 +37,7 @@
     dataFrom="/pageView/path"
     dataDefault="/content/admin/pages"
     suffixToParameter="[path,/pageView/path,path,/state/tools/page]"
-    loaders="[populatePageView:/pageView/path,setInitialPageEditorState:/pageView/path,populateNodesForBrowser:/state/tools/pages,populateComponents:/pageView/path]">
+    loaders="[populatePageView:/pageView/path,setInitialPageEditorState:/pageView/path,populateNodesForBrowser:/state/tools/pages,populateComponents:/pageView/path,populateIcons:/state/tenant]">
 
     <nav jcr:primaryType="nt:unstructured"
       sling:resourceType="admin/components/nav">

--- a/admin-base/ui.apps/src/main/js/stateActions/deleteTenant.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/deleteTenant.js
@@ -22,13 +22,18 @@
  * under the License.
  * #L%
  */
-import { LoggerFactory } from '../logger'
+import {LoggerFactory} from '../logger'
+
 let log = LoggerFactory.logger('deleteTenant').setLevelDebug()
 
 export default function(me, target) {
     log.fine('deleteTenant',target)
     var api = me.getApi()
-    me.getNodeFromView('/state/tools').page = undefined
+
+    if (me.getNodeFromView('/state/tools')) {
+        me.getNodeFromView('/state/tools').page = undefined
+    }
+
     return api.deleteTenant(target).then( () => api.populateTenants() )
 
 }


### PR DESCRIPTION
### FOR DEVELOP-SLING12

I've reviewed some issues with related to inline-editing.

the `icon` action wasn't showing up in the toolbar anymore.
Turned out that `populateIcons:/state/tenant` was missing as a loader inside `admin/pages/pages/edit` 