### PR TITLE
make use of multi stage docker builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:latest
+FROM adoptopenjdk/openjdk11:latest as build
 
 ARG PEREGRINECMS_REPO=https://github.com/headwirecom/peregrine-cms.git
 ARG PEREGRINECMS_BRANCH=develop-sling12
@@ -13,7 +13,9 @@ RUN apt update -q \
     && apt install -q -y --no-install-recommends \
         curl \
         jq \
-        libvips libvips-tools \
+        libvips libvips-tools
+
+RUN apt install -q -y \
         tar \
         xz-utils \
         git \
@@ -47,6 +49,22 @@ RUN scripts/checkout-projects.sh $PEREGRINECMS_REPO $PEREGRINECMS_BRANCH \
     $THEMECLEANFLEX_REPO $THEMECLEANFLEX_BRANCH
 RUN scripts/install-sling.sh
 RUN scripts/install-peregrine.sh
+
+# clean up unnecessary git repos
+RUN rm -rf /app/peregrine-cms /app/themeclean-flex /app/binaries
+
+FROM adoptopenjdk/openjdk11:latest
+
+RUN apt update -q \
+    && apt upgrade -q -y \
+    && apt install -q -y --no-install-recommends \
+        curl \
+        jq \
+        libvips libvips-tools
+
+RUN apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/* && rm -rf /etc/apt/sources.list.d/temp.list;
+
+COPY --from=build /app /app
 
 ENTRYPOINT /app/scripts/start.sh && tail -qF /app/sling/logs/error.log
 

--- a/docker/scripts/checkout-projects.sh
+++ b/docker/scripts/checkout-projects.sh
@@ -17,8 +17,10 @@ THEMECLEANFLEX_BRANCH=$4
 SAVE_PWD=`pwd`
 
 echo "Checking out ${PEREGRINECMS_REPO} and using ${PEREGRINECMS_BRANCH}..."
-git clone ${PEREGRINECMS_REPO}
+git clone --depth 1 ${PEREGRINECMS_REPO}
 cd peregrine-cms
+git remote set-branches origin ${PEREGRINECMS_BRANCH}
+git fetch --depth 1 origin ${PEREGRINECMS_BRANCH}
 git checkout ${PEREGRINECMS_BRANCH}
 
 cd ..


### PR DESCRIPTION
this change to the docker file into a multistage docker build and removing the git repos towards the end of the build before creating the final image drops the final image size from ~4.5GB to 1.25GB