### PR TITLE
Fix com.peregrine.slingjunit.localFS.LocalFSJTest

### DIFF
--- a/slingjunit.parent/README.md
+++ b/slingjunit.parent/README.md
@@ -4,26 +4,30 @@ These test rely on the content deployed from `samples/example-vue-site`
 This is the "example" internal site. 
 
 Deploy the example site
-* cd samples/example-vue-site
-* mvn clean install -PautoDeployPackage
+* `cd samples/example-vue-site`
+* `mvn clean install -P autoInstallPackage`
 
 Deploy Sling Junit Package
-* cd slingjunit.parent
-* mvn clean install -PautoDeployPackage
+* `cd slingjunit.parent`
+* `mvn clean install -P autoInstallPackage`
 
 Run all the tests if you are using `remote` distribution and have both author publish instances running
-* http://localhost:8080/system/sling/junit/
+* [/system/sling/junit](http://localhost:8080/system/sling/junit/)
 
 Otherwise run specific tests
-* /system/sling/junit/com.peregrine.slingjunit.VersionsJTest.html
+* [/system/sling/junit/`com.peregrine.slingjunit.VersionsJTest`.html](http://localhost:8080/system/sling/junit/`com.peregrine.slingjunit.VersionsJTest`.html)
 
 ## Notes:
-1. org.apache.sling.junit.core does need to be in the allowlist for Login Administrative.
-Deploying the bundle directly from peregrine-cms/slingjunit.parent will provide that configuration.  
-   *  mvn clean install -PautoDeployPackage
-2. *RemoteReplAuthorJTest* is a test suite to check remote replication setup (/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html)
-   * For this test to pass, configurations for other replication services (LocalReplicationService and LocalFileSystemReplicationService) may need to be removed. 
-   * If this is run outside of the localhost environment, make sure the default transport user credentials are updated, see UserCredentialsDistributionTransportSecretProvider osgi config
-   * It may be necessary to verify the permissions for service users `distribution-agent-user` and `defaultAgentService` are matching org.apache.sling.jcr.repoinit.RepositoryInitializer~peregrine.json
-3. *PermissionJTest* will fail as everyone has read access on /content by default as a result of base.json (line 335). 
+1. `org.apache.sling.junit.core` does need to be in the `allowlist` for `Login Administrative`.
+Deploying the bundle directly from `peregrine-cms/slingjunit.parent` will provide that configuration.  
+   *  `mvn clean install -PautoDeployPackage`
+2. `RemoteReplAuthorJTest` is a test suite to check remote replication setup
+([/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html](http://localhost:8080/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html))
+   * For this test to pass, configurations for other replication services (`LocalReplicationService` and
+   `LocalFileSystemReplicationService`) may need to be removed. 
+   * If this is run outside of the localhost environment, make sure the default transport user credentials are updated,
+   see `UserCredentialsDistributionTransportSecretProvider` osgi config
+   * It may be necessary to verify the permissions for service users `distribution-agent-user` and `defaultAgentService`
+   are matching `org.apache.sling.jcr.repoinit.RepositoryInitializer~peregrine.json`
+3. `PermissionJTest` will fail as everyone has read access on `/content` by default as a result of `base.json` (line 335). 
 admins may find it more appropriate to remove this ACE depending on their specific requirements. 

--- a/slingjunit.parent/README.md
+++ b/slingjunit.parent/README.md
@@ -14,18 +14,18 @@ Deploy Sling Junit Package
 Run all the tests if you are using `remote` distribution and have both author publish instances running
 * [/system/sling/junit](http://localhost:8080/system/sling/junit/)
 
-Otherwise run specific tests
-* [/system/sling/junit/`com.peregrine.slingjunit.VersionsJTest`.html](http://localhost:8080/system/sling/junit/`com.peregrine.slingjunit.VersionsJTest`.html)
+Otherwise, run specific tests
+* [/system/sling/junit/`com.peregrine.slingjunit.VersionsJTest`.html](http://localhost:8080/system/sling/junit/com.peregrine.slingjunit.VersionsJTest.html)
 
 ## Notes:
 1. `org.apache.sling.junit.core` does need to be in the `allowlist` for `Login Administrative`.
 Deploying the bundle directly from `peregrine-cms/slingjunit.parent` will provide that configuration.  
-   *  `mvn clean install -PautoDeployPackage`
+   *  `mvn clean install -PautoInstallPackage`
 2. `RemoteReplAuthorJTest` is a test suite to check remote replication setup
-([/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html](http://localhost:8080/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html))
+([/system/sling/junit/`com.peregrine.slingjunit.author.RemoteReplAuthorJTest`.html](http://localhost:8080/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html))
    * For this test to pass, configurations for other replication services (`LocalReplicationService` and
    `LocalFileSystemReplicationService`) may need to be removed. 
-   * If this is run outside of the localhost environment, make sure the default transport user credentials are updated,
+   * If this is run outside of the localhost environment, make sure the default transport user credentials get updated,
    see `UserCredentialsDistributionTransportSecretProvider` osgi config
    * It may be necessary to verify the permissions for service users `distribution-agent-user` and `defaultAgentService`
    are matching `org.apache.sling.jcr.repoinit.RepositoryInitializer~peregrine.json`

--- a/slingjunit.parent/core/src/main/java/com/peregrine/slingjunit/localFS/LocalFSJTest.java
+++ b/slingjunit.parent/core/src/main/java/com/peregrine/slingjunit/localFS/LocalFSJTest.java
@@ -2,6 +2,7 @@ package com.peregrine.slingjunit.localFS;
 
 import com.peregrine.adaption.PerReplicable;
 import com.peregrine.replication.Replication;
+import com.peregrine.replication.ReplicationsContainer;
 import com.peregrine.slingjunit.ReplicationTestBase;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
@@ -13,8 +14,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Calendar;
 import static com.peregrine.slingjunit.author.RemoteReplAuthorJTest.STELLA_PNG;
@@ -24,7 +23,8 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(SlingAnnotationsTestRunner.class)
 public class LocalFSJTest extends ReplicationTestBase {
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    public static final String LOCAL_FS = "localFS";
     private Calendar beforeTime;
     @TestReference
     private ResourceResolverFactory resolverFactory;
@@ -34,6 +34,7 @@ public class LocalFSJTest extends ReplicationTestBase {
 //    If possible, remove OSGI configs for unused replication service implementations; remote and local service, before running this test.
 //    Otherwise, since the following line is non-deterministic, it could inject any of the replication services configured.
     @TestReference
+    private ReplicationsContainer replicationsContainer;
     private Replication replication;
     public static String INDEX = "/content/example/pages/index";
     public static String CONTACT = "/content/example/pages/contact";
@@ -48,6 +49,7 @@ public class LocalFSJTest extends ReplicationTestBase {
     @Before
     public void setup(){
         try {
+            replication = replicationsContainer.get(LOCAL_FS);
             beforeTime = Calendar.getInstance();
             adminResourceResolver = resolverFactory.getAdministrativeResourceResolver(null);
             stellaImgRes = adminResourceResolver.getResource(STELLA_PNG);
@@ -70,7 +72,7 @@ public class LocalFSJTest extends ReplicationTestBase {
     @Test
     public void setupIsCorrect(){
         assertNotNull(replication);
-        assertTrue("localFS".equals(replication.getName()));
+        assertEquals(LOCAL_FS, replication.getName());
         assertNotNull(stellaImgRes);
     }
 


### PR DESCRIPTION
#648 enhanced randomly picked `replication` reference - here we're making sure the desired one is used.
The one failing test is left for #658 as it's not related here and the problem was there before already.