### PR TITLE
Fix failing Repo Init

### DIFF
--- a/admin-base/pom.xml
+++ b/admin-base/pom.xml
@@ -69,9 +69,9 @@
     </build>
 
     <modules>
+        <module>sling.ui.apps</module>
         <module>core</module>
         <module>materialize</module>
         <module>ui.apps</module>
-        <module>sling.ui.apps</module>
     </modules>
 </project>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrineAdminBaseUI.config
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrineAdminBaseUI.config
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with this
+# work for additional information regarding copyright ownership. The ASF
+# licenses this file to You under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+scripts=[\
+"
+# This Repoinit Script is here to make sure that during an upgrade the necessary users
+# and permissions are available
+#
+# ATTENTION: because of creating users and groups with path this script depends on org.apache.sling.jcr.repoinit-1.1.10
+#
+
+# set ACL's for all_tenants group on paths lower than root 
+# Note: this replaces jcr:read for everyone on root
+    set ACL for all_tenants
+        allow jcr:read on /index.html
+        allow jcr:read on /favicon.ico
+        allow jcr:read on /robots.txt
+        allow jcr:read on /perapi/admin
+        allow jcr:read on /apps
+        allow jcr:read on /i18n
+        allow jcr:read on /content
+    end
+
+"\
+]

--- a/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
+++ b/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
@@ -30,6 +30,10 @@ scripts=[\
     create path (sling:Folder) /etc/packages
     create path (sling:Folder) /var/recyclebin
     create path (sling:Folder) /var/sitemaps
+    create path (sling:Folder) /etc/distribution
+    create path (sling:Folder) /i18n
+    create path (sling:Folder) /libs/sling/distribution
+    create path (sling:Folder) /var/sling/distribution
 
 # Create the Peregrine Service Users
     create service user peregrine-service-user
@@ -72,17 +76,6 @@ scripts=[\
         allow jcr:read on /content
     end
 
-# set ACL's for all_tenants group on paths lower than root 
-# Note: this replaces jcr:read for everyone on root
-    set ACL for all_tenants
-        allow jcr:read on /index.html
-        allow jcr:read on /favicon.ico
-        allow jcr:read on /robots.txt
-        allow jcr:read on /perapi/admin
-        allow jcr:read on /apps
-        allow jcr:read on /i18n
-        allow jcr:read on /content
-    end
 
 # Create Tenant Groups for Peregrine
     create group all_tenants with path /home/groups/tenants


### PR DESCRIPTION
Moved failing repoinit directives for files to admin-base/ui.apps, so that they exist when setting their ACL's. Added 'create folder' directives for folders that might not exist yet in RepositoryInitializer-peregrine.config.

Multiple [error messages](https://github.com/headwirecom/peregrine-cms/issues/677#issuecomment-741015544) were observed upon initial package deployments after creating a new instance. Setting proper ACL's will not work if the resource paths are not created. 

This Platform module configuration attempts to set ACL's for paths created by other modules such as admin-base or replication. If those missing resources were folders, then `create path` directives were added. ACL directives setting files were moved to the respective package that created the files (`admin-base/ui.apps`)

