### PR TITLE
Issues/460 develop xmlhelper for svg

### DIFF
--- a/platform/base/core/src/main/java/com/peregrine/adaption/PerAsset.java
+++ b/platform/base/core/src/main/java/com/peregrine/adaption/PerAsset.java
@@ -119,5 +119,11 @@ public interface PerAsset
      * get dimension (or null) for asset
      */
     Dimension getDimension() throws RepositoryException, IOException;
-    
+
+
+    /**
+     * get asset mime type
+     */
+    String getMimeType();
+
 }

--- a/platform/base/core/src/main/java/com/peregrine/assets/XMLHelper.java
+++ b/platform/base/core/src/main/java/com/peregrine/assets/XMLHelper.java
@@ -1,0 +1,86 @@
+package com.peregrine.assets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.awt.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.isAlphanumeric;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
+import static org.apache.commons.lang3.StringUtils.replaceAll;
+import static org.apache.commons.lang3.StringUtils.split;
+import static org.apache.commons.lang3.StringUtils.startsWith;
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
+
+public class XMLHelper {
+
+    private static Logger logger = LoggerFactory.getLogger(XMLHelper.class);
+
+    public static Document getXmlDocument(InputStream inputStream) {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        Document doc = null;
+        DocumentBuilder builder = null;
+        try {
+            builder = factory.newDocumentBuilder();
+            doc = builder.parse(inputStream);
+        } catch (ParserConfigurationException | SAXException e) {
+            logger.error("error creating xml doc from inputstream", e);
+        }  catch (IOException e) {
+            logger.error("error creating xml doc from inputstream", e);
+        }
+        return doc;
+    }
+
+    public static void closeInputStream(InputStream inputStream){
+        try {
+            inputStream.close();
+        } catch (IOException e) {
+            logger.error("error closing inputstream", e);
+        }
+    }
+
+    public static String normalizeSVGAlphanumeric(final String string) {
+        var result = lowerCase(string);
+        result = substringBeforeLast(result, "pt");
+        return substringBeforeLast(result, ".");
+    }
+
+    public static boolean isExtendedAlphanumeric(final String string) {
+        if (startsWith(string, "-")) {
+            return isAlphanumeric(substringAfter(string, "-"));
+        }
+        return isAlphanumeric(string);
+    }
+
+    public static Rectangle parseRectangle(final String string) {
+        if (isBlank(string)) {
+            return null;
+        }
+        final var normalized = replaceAll(string, "\\s+", " ");
+        final var parts = Arrays.stream(split(normalized, " "))
+                .filter(XMLHelper::isExtendedAlphanumeric)
+                .map(XMLHelper::normalizeSVGAlphanumeric)
+                .map(Integer::parseInt)
+                .collect(Collectors.toList());
+        if (parts.size() != 4) {
+            return null;
+        }
+        return new Rectangle(
+                parts.remove(0),
+                parts.remove(0),
+                parts.remove(0),
+                parts.remove(0)
+        );
+    }
+}

--- a/platform/base/core/src/main/java/com/peregrine/assets/XMLHelper.java
+++ b/platform/base/core/src/main/java/com/peregrine/assets/XMLHelper.java
@@ -8,7 +8,7 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.awt.*;
+import java.awt.Rectangle;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;


### PR DESCRIPTION
PerAssetImpl appeared to be getting a little busy with all the SVG String operations. And since SVG is XML, probably would be better to use Java libraries for reading the doc and attributes instead of parsing Strings directly from input streams. I moved some of the methods that can static into XMLHelper, and looked through to try and close inputstreams and ImageInputStream