### PR TITLE
#691: allow read access to all tenants on /perapi instead of /perapi/admin

### DIFF
--- a/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
+++ b/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
@@ -72,20 +72,20 @@ scripts=[\
         allow jcr:read on /content
     end
 
+# Create Tenant Groups for Peregrine
+    create group all_tenants with path /home/groups/tenants
+
 # set ACL's for all_tenants group on paths lower than root 
 # Note: this replaces jcr:read for everyone on root
     set ACL for all_tenants
         allow jcr:read on /index.html
         allow jcr:read on /favicon.ico
         allow jcr:read on /robots.txt
-        allow jcr:read on /perapi/admin
+        allow jcr:read on /perapi
         allow jcr:read on /apps
         allow jcr:read on /i18n
         allow jcr:read on /content
     end
-
-# Create Tenant Groups for Peregrine
-    create group all_tenants with path /home/groups/tenants
 
 "\
 ]


### PR DESCRIPTION
I changed the all_tenants/jcr:read from /perapi/admin to /perapi - I don't see any harm in this change (was a jcr:read before as well on sling9 with the previous configs) - would love to hear if everybody agrees or not