### PR TITLE
Better blank value check for Range Slider

### DIFF
--- a/admin-base/materialize/custom/_vue-form-generator.scss
+++ b/admin-base/materialize/custom/_vue-form-generator.scss
@@ -880,16 +880,7 @@
         }
 
         .empty-range {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            width: 100%;
-
-            .rail {
-                width: 100%;
-                height: 3px;
-                background-color: #c2c2c2;
-            }
+            opacity: .5;
         }
 
         .range-numbers {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="!schema.preview" class="range-field" :class="{'is-empty': !value}">
     <button class="range-btn" @click="onRangeBtnClick">
-      <admin-components-icon :icon="icon" :lib="IconLib.MATERIAL_ICONS"/>
       <span v-if="!value" class="strike"></span>
+      <admin-components-icon icon="linear_scale" :lib="IconLib.MATERIAL_ICONS"/>
     </button>
     <input
         ref="range"
@@ -68,9 +68,6 @@ export default {
     max() {
       return this.schema.max || 100
     },
-    icon() {
-      return 'linear_scale'
-    }
   },
   watch: {
     value(val) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="!schema.preview" class="range-field" :class="{'is-empty': value === null}">
     <button class="range-btn" @click="onRangeBtnClick">
-      <admin-components-icon :icon="icon" :lib="IconLib.MATERIAL_ICONS"/>
+      <admin-components-icon icon="linear_scale" :lib="IconLib.MATERIAL_ICONS"/>
       <span v-if="value === null" class="strike"></span>
     </button>
     <input
@@ -67,9 +67,6 @@ export default {
     },
     max() {
       return this.schema.max || 100
-    },
-    icon() {
-      return 'linear_scale'
     }
   },
   watch: {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -18,8 +18,8 @@
         :name="schema.inputName"
         :required="schema.required"
         :step="schema.step"/>
-      <div class="rail" @click="value = 0"></div>
     <div v-if="isBlank" class="empty-range">
+      <div class="rail" @click="value = min"></div>
     </div>
     <input
         type="text"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="!schema.preview" class="range-field" :class="{'is-empty': isBlank}">
     <button class="range-btn" @click="onRangeBtnClick">
-      <span v-if="isBlank" class="strike"></span>
       <admin-components-icon icon="linear_scale" :lib="IconLib.MATERIAL_ICONS"/>
+      <span v-if="isBlank" class="strike"></span>
     </button>
     <input
         ref="range"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="!schema.preview" class="range-field" :class="{'is-empty': !value}">
+  <div v-if="!schema.preview" class="range-field" :class="{'is-empty': value === null}">
     <button class="range-btn" @click="onRangeBtnClick">
       <admin-components-icon :icon="icon" :lib="IconLib.MATERIAL_ICONS"/>
-      <span v-if="!value" class="strike"></span>
+      <span v-if="value === null" class="strike"></span>
     </button>
     <input
         ref="range"
@@ -10,7 +10,7 @@
         class="range"
         v-model="value"
         :id="getFieldID(schema)"
-        :class="[schema.fieldClasses, {hidden: !value}]"
+        :class="[schema.fieldClasses, {hidden: value === null}]"
         :disabled="schema.disabled || schema.preview"
         :alt="schema.alt"
         :max="schema.max"
@@ -18,7 +18,7 @@
         :name="schema.inputName"
         :required="schema.required"
         :step="schema.step"/>
-    <div v-if="!value" class="empty-range">
+    <div v-if="value === null" class="empty-range">
       <div class="rail" @click="value = 0"></div>
     </div>
     <input
@@ -101,7 +101,7 @@ export default {
   },
   methods: {
     onRangeBtnClick() {
-      if (this.value) {
+      if (this.value !== null) {
         this.oldValue = this.value
         this.value = null
       } else {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -35,10 +35,6 @@
         :required="schema.required"
         @keypress="onRangeValueKeyPress"
         @paste="onRangeValuePaste"/>
-    <!--div class="range-numbers">
-      <div class="min">{{ min }}</div>
-      <div class="max">{{ max }}</div>
-    </div-->
   </div>
   <div v-else>{{ value }}</div>
 </template>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -5,12 +5,13 @@
       <span v-if="value === null" class="strike"></span>
     </button>
     <input
+        v-if="value !== null"
         ref="range"
         type="range"
         class="range"
         v-model="value"
         :id="getFieldID(schema)"
-        :class="[schema.fieldClasses, {hidden: value === null}]"
+        :class="[schema.fieldClasses]"
         :disabled="schema.disabled || schema.preview"
         :alt="schema.alt"
         :max="schema.max"
@@ -18,9 +19,14 @@
         :name="schema.inputName"
         :required="schema.required"
         :step="schema.step"/>
-    <div v-if="value === null" class="empty-range">
-      <div class="rail" @click="value = 0"></div>
-    </div>
+    <input
+        v-if="value === null"
+        type="range"
+        class="empty-range range"
+        :value="50"
+        min="0"
+        max="100"
+        disabled>
     <input
         type="text"
         class="range-value"
@@ -74,7 +80,7 @@ export default {
       this.model[this.schema.model] = val
 
       let propsToRemove = this.model['_opDeleteProps'] || []
-      if (val || val === 0 || val === "0") {
+      if (val || val === 0 || val === '0') {
         propsToRemove = propsToRemove.filter(x => x !== this.schema.model)
       } else {
         propsToRemove.push(this.schema.model)

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/field/material-range/template.vue
@@ -1,7 +1,7 @@
 <template>
-  <div v-if="!schema.preview" class="range-field" :class="{'is-empty': !value}">
+  <div v-if="!schema.preview" class="range-field" :class="{'is-empty': isBlank}">
     <button class="range-btn" @click="onRangeBtnClick">
-      <span v-if="!value" class="strike"></span>
+      <span v-if="isBlank" class="strike"></span>
       <admin-components-icon icon="linear_scale" :lib="IconLib.MATERIAL_ICONS"/>
     </button>
     <input
@@ -10,7 +10,7 @@
         class="range"
         v-model="value"
         :id="getFieldID(schema)"
-        :class="[schema.fieldClasses, {hidden: !value}]"
+        :class="[schema.fieldClasses, {hidden: isBlank}]"
         :disabled="schema.disabled || schema.preview"
         :alt="schema.alt"
         :max="schema.max"
@@ -18,8 +18,8 @@
         :name="schema.inputName"
         :required="schema.required"
         :step="schema.step"/>
-    <div v-if="!value" class="empty-range">
       <div class="rail" @click="value = 0"></div>
+    <div v-if="isBlank" class="empty-range">
     </div>
     <input
         type="text"
@@ -46,6 +46,10 @@
 <script>
 import {IconLib, Toast} from '../../../../../js/constants'
 
+function isDefined(value) {
+  return value || value === 0 || value === "0"
+}
+
 export default {
   mixins: [VueFormGenerator.abstractField],
   data() {
@@ -68,13 +72,16 @@ export default {
     max() {
       return this.schema.max || 100
     },
+    isBlank() {
+      return !isDefined(this.value)
+    }
   },
   watch: {
     value(val) {
       this.model[this.schema.model] = val
 
       let propsToRemove = this.model['_opDeleteProps'] || []
-      if (val || val === 0 || val === "0") {
+      if (isDefined(val)) {
         propsToRemove = propsToRemove.filter(x => x !== this.schema.model)
       } else {
         propsToRemove.push(this.schema.model)
@@ -98,7 +105,7 @@ export default {
   },
   methods: {
     onRangeBtnClick() {
-      if (this.value) {
+      if (!this.isBlank) {
         this.oldValue = this.value
         this.value = null
       } else {


### PR DESCRIPTION
Some behaviors did not click right as `0` and/or `"0"` behave the way they do when viewed as a `boolean`.