### PR TITLE
Simplify aspects of replication FE

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/servlets/ReplicationServlet.java
@@ -63,7 +63,7 @@ import static org.osgi.framework.Constants.SERVICE_VENDOR;
  * and any references
  *
  * The API Definition can be found in the Swagger Editor configuration:
- *    ui.apps/src/main/content/jcr_root/api/definitions/admin.yaml
+ *    ui.apps/src/main/content/jcr_root/perapi/definitions/admin.yaml
  *
  * It is invoked like this:
  *      curl -X POST "http://localhost:8080/perapi/admin/repl.json/content/themeclean" -H  "accept: application/json" -H  "content-type: application/x-www-form-urlencoded" -d "name=defaultRepl&deep=false"

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -349,15 +349,11 @@ export default {
 
             replicatedClass(item) {
                 if(item.ReplicationStatus) {
-                    const created = item.created
-                    const modified = item.lastModified ? item.lastModified : created
+                    const modified = item.lastModified || item.created
                     const replicated = item.Replicated
-                    if(replicated > modified) {
-                        return 'item-'+item.ReplicationStatus
-                    } else {
-                        return 'item-'+item.ReplicationStatus+'-modified'
-                    }
+                    return `item-${item.ReplicationStatus}${replicated < modified ? '-modified' : ''}`
                 }
+
                 return 'item-replication-unknown'
             },
 

--- a/admin-base/ui.apps/src/main/content/jcr_root/perapi/definitions/admin.yaml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/perapi/definitions/admin.yaml
@@ -900,7 +900,7 @@ paths:
           type: string
           in: formData
           description: the name of the replication service to be used
-          required: true
+          required: false
         - name: deep
           type: boolean
           in: formData

--- a/admin-base/ui.apps/src/main/js/api.js
+++ b/admin-base/ui.apps/src/main/js/api.js
@@ -275,8 +275,8 @@ class PerApi {
         return impl.moveNodeTo(path, component, drop)
     }
 
-    replicate(path, replicationService, deep, deactivate, references) {
-        return impl.replicate(path, replicationService, deep, deactivate, references)
+    replicate(path, deep, deactivate, references) {
+        return impl.replicate(path, deep, deactivate, references)
     }
 
     getPalettes(templateName) {

--- a/admin-base/ui.apps/src/main/js/apiImpl.js
+++ b/admin-base/ui.apps/src/main/js/apiImpl.js
@@ -1140,58 +1140,64 @@ class PerAdminImpl {
     return updateWithForm('/admin/moveNodeTo.json' + path, formData)
   }
 
-replicate(path, replicationService='', deep=false, deactivate=false, resources=[]) {
-  const timeNow = Date.now() - 1000
-  let noticeFunction = undefined
-  let count = 0
-  console.log(`time now = ${timeNow}`)
+  replicate(path, deep=false, deactivate=false, resources=[]) {
+    const timeNow = Date.now() - 1000
+    let noticeFunction = undefined
+    let count = 0
+    console.log(`time now = ${timeNow}`)
     return new Promise((resolve, reject) => {
       let formData = new FormData();
       formData.append('deep', deep)
-      formData.append('name', replicationService)
       formData.append('deactivate', deactivate)
-      resources.forEach((ref) => formData.append('resources', ref))      
+      resources.forEach((ref) => formData.append('resources', ref))
       updateWithForm('/admin/repl.json' + path, formData)
-          .then((respData)=>{
-            count = 0
-            noticeFunction = setInterval(function(){    
-                return fetch(`/admin/listReplicationStatus.json${respData.sourcePath}`)
-                  .then((data) => {
-                    let stopPolling = false
-                    if (count++ >= 25) {
-                      stopPolling = true
-                      clearInterval(noticeFunction)
-                      $perAdminApp.notifyUser('Error', `Action timed out when ${deactivate?'un':''}publishing ${data.sourcePath}.`)
-                      reject()
-                      return                      
-                    }
-                    if (data['per:ReplicationLastAction'] === "deactivated" && data['activated'] === false && !data['per:ReplicationRef']) {
-                      stopPolling = true
-                    } else if (data['per:ReplicationLastAction'] === "activated" 
-                        && data['activated'] === true  && data['per:Replicated'] && timeNow < Date.parse(data['per:Replicated'])
-                        && data['per:ReplicationRef'] && data['per:ReplicationRef'].indexOf("pending") < 0) {
-                          stopPolling = true
-                    }
-
-                    if (stopPolling) {
-                        const parentPath = path.substring(0, path.lastIndexOf("/"))
-                        $perAdminApp.getApi().populateNodesForBrowser(parentPath)
-                        clearInterval(noticeFunction)
-                        $perAdminApp.notifyUser('Success', `${data.sourcePath} was successfuly ${deactivate?'un':''}published.`)
-                      }
-                  })
-              }, 500);
-          })
-          .then(() => resolve())
-          .catch(error => {            
-              clearInterval(noticeFunction)
-              $perAdminApp.notifyUser('Errors', `were encountered when ${deactivate?'un':''}publishing ${data.sourcePath}. Please check with your admin.`)
-              if (error.response && error.response.data && error.response.data.message) {
-                reject(error.response.data.message)
+        .then(respData => {
+          count = 0
+          noticeFunction = setInterval(function() {
+            function stopPolling(data) {
+              const lastAction = data['per:ReplicationLastAction']
+              const activated = data['activated']
+              const ref = data['per:ReplicationRef']
+              const replicated = data['per:Replicated']
+              let stopPolling = false
+              if (lastAction === "deactivated" && activated === false && !ref) {
+                return true
               }
-              reject(error)
-          })
-    })  
+
+              if (lastAction === "activated" && activated === true
+                      && replicated && timeNow < Date.parse(replicated)
+                      && ref !== "distribution pending") {
+                return true
+              }
+
+              return false
+            }
+
+            return fetch(`/admin/listReplicationStatus.json${respData.sourcePath}`)
+              .then(data => {
+                if (count++ >= 25) {
+                  clearInterval(noticeFunction)
+                  $perAdminApp.notifyUser('Error', `Action timed out when ${deactivate?'un':''}publishing ${data.sourcePath}.`)
+                  reject()
+                } else if (stopPolling(data)) {
+                  clearInterval(noticeFunction)
+                  const parentPath = path.substring(0, path.lastIndexOf("/"))
+                  $perAdminApp.getApi().populateNodesForBrowser(parentPath)
+                  $perAdminApp.notifyUser('Success', `${data.sourcePath} was successfully ${deactivate?'un':''}published.`)
+                }
+              })
+          }, 500);
+        })
+        .then(() => resolve())
+        .catch(error => {
+          clearInterval(noticeFunction)
+          $perAdminApp.notifyUser('Errors', `were encountered when ${deactivate?'un':''}publishing ${data.sourcePath}. Please check with your admin.`)
+          if (error.response && error.response.data && error.response.data.message) {
+            reject(error.response.data.message)
+          }
+          reject(error)
+        })
+    })
   }
 
 

--- a/admin-base/ui.apps/src/main/js/stateActions/publish.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/publish.js
@@ -27,5 +27,5 @@ let log = LoggerFactory.logger('replicate').setLevelDebug()
 
 export default function(me, target) {
     log.fine(target)    
-    return me.getApi().replicate(target.path, 'defaultRepl', false, false, target.references)
+    return me.getApi().replicate(target.path, false, false, target.references)
 }

--- a/admin-base/ui.apps/src/main/js/stateActions/unreplicate.js
+++ b/admin-base/ui.apps/src/main/js/stateActions/unreplicate.js
@@ -27,5 +27,5 @@ let log = LoggerFactory.logger('unreplicate').setLevelDebug()
 
 export default function(me, target) {
     log.fine(target)    
-    return me.getApi().replicate(target, 'defaultRepl', false, true, undefined)
+    return me.getApi().replicate(target, false, true, undefined)
 }


### PR DESCRIPTION
Batch of changes for #658. The full fix will come in smaller chunks easier to consume.

We simplify small stuff btw here.
We remove `replicationService` parameter as it's unused and actually incorrect - we should not hardcode `defaultRepl` in FE as it's a name configurable in `OSGi`.
`pending` check is more detailed since at this point it grabbed e.g. `/content/tenant/pages/pending-reviews`.
`replicate` function is flattened a bit.