### PR TITLE
Implement: unhide child pages from sitemap

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -282,7 +282,7 @@ export default {
             },
             children: function() {
                 if ( this.pt.children ) {
-                    return this.pt.children.filter(this.checkIfAllowed)
+                    return this.pt.children.filter( child => this.checkIfAllowed(child) )
                 }
             },
             parentPath: function() {
@@ -524,13 +524,11 @@ export default {
             },
 
             checkIfAllowed: function(node) {
-                const { resourceType } = node
-                if(this.model.showFilter === 'true' && this.filter) {
-                    if(node.excludeFromSitemap === 'true') return false
-                    return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition'].indexOf(resourceType) >= 0
+                if(this.model.showFilter && this.model.showFilter === 'true' && this.filter) {
+                    if(node.excludeFromSitemap && node.excludeFromSitemap === 'true') return false
+                    return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition'].indexOf(node.resourceType) >= 0
                 }
-
-                return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition', 'nt:file', 'sling:Folder', 'sling:OrderedFolder', 'sling:OrderedFolder'].indexOf(resourceType) >= 0
+                return ['per:Asset', 'nt:file', 'sling:Folder', 'sling:OrderedFolder', 'per:Page', 'sling:OrderedFolder', 'per:Object', 'per:ObjectDefinition'].indexOf(node.resourceType) >= 0
             },
 
             showInfo: function(me, target) {

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorer/template.vue
@@ -282,7 +282,7 @@ export default {
             },
             children: function() {
                 if ( this.pt.children ) {
-                    return this.pt.children.filter( child => this.checkIfAllowed(child) )
+                    return this.pt.children.filter(this.checkIfAllowed)
                 }
             },
             parentPath: function() {
@@ -524,11 +524,13 @@ export default {
             },
 
             checkIfAllowed: function(node) {
-                if(this.model.showFilter && this.model.showFilter === 'true' && this.filter) {
-                    if(node.excludeFromSitemap && node.excludeFromSitemap === 'true') return false
-                    return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition'].indexOf(node.resourceType) >= 0
+                const { resourceType } = node
+                if(this.model.showFilter === 'true' && this.filter) {
+                    if(node.excludeFromSitemap === 'true') return false
+                    return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition'].indexOf(resourceType) >= 0
                 }
-                return ['per:Asset', 'nt:file', 'sling:Folder', 'sling:OrderedFolder', 'per:Page', 'sling:OrderedFolder', 'per:Object', 'per:ObjectDefinition'].indexOf(node.resourceType) >= 0
+
+                return ['per:Page', 'per:Asset', 'per:Object', 'per:ObjectDefinition', 'nt:file', 'sling:Folder', 'sling:OrderedFolder', 'sling:OrderedFolder'].indexOf(resourceType) >= 0
             },
 
             showInfo: function(me, target) {

--- a/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/explorer_dialog.json
+++ b/pagerenderer/vue/ui.apps/src/main/content/jcr_root/apps/pagerendervue/structure/page/explorer_dialog.json
@@ -115,13 +115,23 @@
   },
   {
     "type": "materialswitch",
-    "label": "Exclude from Sitemap",
+    "label": "Exclude Page from Sitemap",
     "model": "excludeFromSitemap",
     "textOn": "yes",
     "textOff": "no",
     "valueOn": "true",
     "valueOff": "false",
-    "hint": "This property indicates if the Page should be hidden from the Sitemap."
+    "hint": "This property indicates if the Page should be hidden from the Sitemap. It will not affect its children. If you'd like to affect the children - use the property below."
+  },
+  {
+    "type": "materialswitch",
+    "label": "Exclude Tree from Sitemap",
+    "model": "excludeTreeFromSitemap",
+    "textOn": "yes",
+    "textOff": "no",
+    "valueOn": "true",
+    "valueOff": "false",
+    "hint": "This property indicates if the whole Sub-Tree under this Page should be hidden from the Sitemap. It will not affect the Page though. If you'd like to affect the Page - use the property above."
   },
   {
     "type": "material-select",

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizer.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizer.java
@@ -31,4 +31,8 @@ public interface PageRecognizer extends HasName {
 
     boolean isPage(Page candidate);
 
+    default boolean isBucket(Page candidate) {
+        return isPage(candidate);
+    }
+
 }

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
@@ -36,22 +36,22 @@ public abstract class PageRecognizerBase implements PageRecognizer {
 
     private final String pagePrimaryType;
     private final String pageContentPrimaryType;
-    private final String excludePageFromSiteMapPropertyName;
+    private final String excludeFromSiteMapPropertyName;
     private final String excludeTreeFromSiteMapPropertyName;
 
     protected PageRecognizerBase(
             final String pagePrimaryType,
             final String pageContentPrimaryType,
-            final String excludePageFromSiteMapPropertyName,
+            final String excludeFromSiteMapPropertyName,
             final String excludeTreeFromSiteMapPropertyName) {
         this.pagePrimaryType = pagePrimaryType;
         this.pageContentPrimaryType = pageContentPrimaryType;
-        this.excludePageFromSiteMapPropertyName = excludePageFromSiteMapPropertyName;
+        this.excludeFromSiteMapPropertyName = excludeFromSiteMapPropertyName;
         this.excludeTreeFromSiteMapPropertyName = excludeTreeFromSiteMapPropertyName;
     }
 
     public final boolean isPage(final Page candidate) {
-        return isAPageBasically(candidate) && !isExcludedByProperty(excludePageFromSiteMapPropertyName, candidate);
+        return isAPageBasically(candidate) && !isExcludedByProperty(excludeFromSiteMapPropertyName, candidate);
     }
 
     public final boolean isBucket(final Page candidate) {
@@ -95,8 +95,8 @@ public abstract class PageRecognizerBase implements PageRecognizer {
         return pageContentPrimaryType;
     }
 
-    public String getExcludePageFromSiteMapPropertyName() {
-        return excludePageFromSiteMapPropertyName;
+    public String getExcludeFromSiteMapPropertyName() {
+        return excludeFromSiteMapPropertyName;
     }
 
 }

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
@@ -51,14 +51,14 @@ public abstract class PageRecognizerBase implements PageRecognizer {
     }
 
     public final boolean isPage(final Page candidate) {
-        return isAPageBasically(candidate) && !isExcludedByProperty(excludeFromSiteMapPropertyName, candidate);
+        return hasAllPageMarkers(candidate) && !isExcludedByProperty(excludeFromSiteMapPropertyName, candidate);
     }
 
     public final boolean isBucket(final Page candidate) {
-        return isAPageBasically(candidate) && !isExcludedByProperty(excludeTreeFromSiteMapPropertyName, candidate);
+        return hasAllPageMarkers(candidate) && !isExcludedByProperty(excludeTreeFromSiteMapPropertyName, candidate);
     }
 
-    private boolean isAPageBasically(final Page candidate) {
+    private boolean hasAllPageMarkers(final Page candidate) {
         if (!isUnfrozenPrimaryType(candidate, pagePrimaryType)) {
             return false;
         }

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/PageRecognizerBase.java
@@ -36,18 +36,29 @@ public abstract class PageRecognizerBase implements PageRecognizer {
 
     private final String pagePrimaryType;
     private final String pageContentPrimaryType;
-    private final String excludeFromSiteMapPropertyName;
+    private final String excludePageFromSiteMapPropertyName;
+    private final String excludeTreeFromSiteMapPropertyName;
 
     protected PageRecognizerBase(
             final String pagePrimaryType,
             final String pageContentPrimaryType,
-            final String excludeFromSiteMapPropertyName) {
+            final String excludePageFromSiteMapPropertyName,
+            final String excludeTreeFromSiteMapPropertyName) {
         this.pagePrimaryType = pagePrimaryType;
         this.pageContentPrimaryType = pageContentPrimaryType;
-        this.excludeFromSiteMapPropertyName = excludeFromSiteMapPropertyName;
+        this.excludePageFromSiteMapPropertyName = excludePageFromSiteMapPropertyName;
+        this.excludeTreeFromSiteMapPropertyName = excludeTreeFromSiteMapPropertyName;
     }
 
     public final boolean isPage(final Page candidate) {
+        return isAPageBasically(candidate) && !isExcludedByProperty(excludePageFromSiteMapPropertyName, candidate);
+    }
+
+    public final boolean isBucket(final Page candidate) {
+        return isAPageBasically(candidate) && !isExcludedByProperty(excludeTreeFromSiteMapPropertyName, candidate);
+    }
+
+    private boolean isAPageBasically(final Page candidate) {
         if (!isUnfrozenPrimaryType(candidate, pagePrimaryType)) {
             return false;
         }
@@ -64,14 +75,14 @@ public abstract class PageRecognizerBase implements PageRecognizer {
             return false;
         }
 
-        if (Optional.ofNullable(candidate.getProperty(excludeFromSiteMapPropertyName))
+        return isPageImpl(candidate);
+    }
+
+    private Boolean isExcludedByProperty(final String propertyName, final Page candidate) {
+        return Optional.ofNullable(candidate.getProperty(propertyName))
                 .map(String::valueOf)
                 .map(Boolean::parseBoolean)
-                .orElse(false)) {
-            return false;
-        }
-
-        return isPageImpl(candidate);
+                .orElse(false);
     }
 
     protected abstract boolean isPageImpl(final Page candidate);
@@ -84,8 +95,8 @@ public abstract class PageRecognizerBase implements PageRecognizer {
         return pageContentPrimaryType;
     }
 
-    public String getExcludeFromSiteMapPropertyName() {
-        return excludeFromSiteMapPropertyName;
+    public String getExcludePageFromSiteMapPropertyName() {
+        return excludePageFromSiteMapPropertyName;
     }
 
 }

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/impl/PerPageRecognizerBase.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/impl/PerPageRecognizerBase.java
@@ -32,7 +32,7 @@ import static com.peregrine.commons.util.PerConstants.*;
 public abstract class PerPageRecognizerBase extends PageRecognizerBase {
 
     public PerPageRecognizerBase() {
-        super(PAGE_PRIMARY_TYPE, PAGE_CONTENT_TYPE, EXCLUDE_FROM_SITEMAP);
+        super(PAGE_PRIMARY_TYPE, PAGE_CONTENT_TYPE, EXCLUDE_PAGE_FROM_SITEMAP, EXCLUDE_TREE_FROM_SITEMAP);
     }
 
 }

--- a/platform/base/core/src/main/java/com/peregrine/sitemap/impl/PerPageRecognizerBase.java
+++ b/platform/base/core/src/main/java/com/peregrine/sitemap/impl/PerPageRecognizerBase.java
@@ -32,7 +32,7 @@ import static com.peregrine.commons.util.PerConstants.*;
 public abstract class PerPageRecognizerBase extends PageRecognizerBase {
 
     public PerPageRecognizerBase() {
-        super(PAGE_PRIMARY_TYPE, PAGE_CONTENT_TYPE, EXCLUDE_PAGE_FROM_SITEMAP, EXCLUDE_TREE_FROM_SITEMAP);
+        super(PAGE_PRIMARY_TYPE, PAGE_CONTENT_TYPE, EXCLUDE_FROM_SITEMAP, EXCLUDE_TREE_FROM_SITEMAP);
     }
 
 }

--- a/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
+++ b/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
@@ -6,8 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static com.peregrine.commons.util.PerConstants.JCR_PRIMARY_TYPE;
-import static com.peregrine.commons.util.PerConstants.SLING_RESOURCE_TYPE;
+import static com.peregrine.commons.util.PerConstants.*;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -26,7 +25,7 @@ public class PageRecognizerBaseTest extends SlingResourcesTest {
     }
 
     public PageRecognizerBaseTest() {
-        this(new PageRecognizerBase(PRIMARY_TYPE, CONTENT_TYPE, EXCLUDE_SITE_MAP_PROPERTY) {
+        this(new PageRecognizerBase(PRIMARY_TYPE, CONTENT_TYPE, EXCLUDE_SITE_MAP_PROPERTY, EXCLUDE_TREE_FROM_SITEMAP) {
             @Override
             protected boolean isPageImpl(final Page candidate) {
                 return true;
@@ -45,7 +44,7 @@ public class PageRecognizerBaseTest extends SlingResourcesTest {
         assertFalse(model.isPage(candidate));
         page.putProperty(SLING_RESOURCE_TYPE, RESOURCE_TYPE);
         assertTrue(model.isPage(candidate));
-        page.putProperty(model.getExcludeFromSiteMapPropertyName(), true);
+        page.putProperty(model.getExcludePageFromSiteMapPropertyName(), true);
         assertFalse(model.isPage(candidate));
     }
 

--- a/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
+++ b/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
@@ -46,7 +46,7 @@ public class PageRecognizerBaseTest extends SlingResourcesTest {
         assertFalse(model.isPage(candidate));
         page.putProperty(SLING_RESOURCE_TYPE, RESOURCE_TYPE);
         assertTrue(model.isPage(candidate));
-        page.putProperty(model.getExcludePageFromSiteMapPropertyName(), true);
+        page.putProperty(model.getExcludeFromSiteMapPropertyName(), true);
         assertFalse(model.isPage(candidate));
     }
 

--- a/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
+++ b/platform/base/core/src/test/java/com/peregrine/sitemap/PageRecognizerBaseTest.java
@@ -6,7 +6,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static com.peregrine.commons.util.PerConstants.*;
+import static com.peregrine.commons.util.PerConstants.EXCLUDE_TREE_FROM_SITEMAP;
+import static com.peregrine.commons.util.PerConstants.JCR_PRIMARY_TYPE;
+import static com.peregrine.commons.util.PerConstants.SLING_RESOURCE_TYPE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
@@ -157,7 +157,8 @@ public class PerConstants {
     public static final String INTERNAL = "internal";
     public static final String DOMAINS = "domains";
 
-    public static final String EXCLUDE_FROM_SITEMAP = "excludeFromSitemap";
+    public static final String EXCLUDE_PAGE_FROM_SITEMAP = "excludeFromSitemap";
+    public static final String EXCLUDE_TREE_FROM_SITEMAP = "excludeTreeFromSitemap";
     public static final String CHANGE_FREQUENCY = "changefreq";
     public static final String PRIORITY = "priority";
 

--- a/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
+++ b/platform/commons/src/main/java/com/peregrine/commons/util/PerConstants.java
@@ -157,7 +157,7 @@ public class PerConstants {
     public static final String INTERNAL = "internal";
     public static final String DOMAINS = "domains";
 
-    public static final String EXCLUDE_PAGE_FROM_SITEMAP = "excludeFromSitemap";
+    public static final String EXCLUDE_FROM_SITEMAP = "excludeFromSitemap";
     public static final String EXCLUDE_TREE_FROM_SITEMAP = "excludeTreeFromSitemap";
     public static final String CHANGE_FREQUENCY = "changefreq";
     public static final String PRIORITY = "priority";


### PR DESCRIPTION
Implements #546. I am adding a new property `excludeTreeFromSitemap` that works along `excludeFromSitemap`. They are independent now and allow to hide either the page alone or its subtree in site map. It requires content adjustment (I don't see a feasible solution that wouldn't). Requires [180](https://github.com/headwirecom/themeclean-flex/pull/180) to run properly.