### PR TITLE
fix: editable-actions visiblity on component select

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/contentview/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/contentview/template.vue
@@ -966,6 +966,7 @@ export default {
         this.editable.styles.left = `${left + offset.left}px`
         this.editable.styles.width = `${width}px`
         this.editable.styles.height = `${height}px`
+        this.editable.class = 'selected'
       })
     },
 


### PR DESCRIPTION
quick fix.
fixes that the editbale actions don't initially show up. Only after triggering an inline-edit