### PR TITLE
Fix remote repl sling12

### DIFF
--- a/docs/public/distribution/index.md
+++ b/docs/public/distribution/index.md
@@ -14,10 +14,10 @@ the term Distribution to go along with the Sling parlance.
 
 These are the current supported distributions:
 
-1. Local, in-Peregrine Copies
-1. Remote Sling Distributions (Peregrine to remote Peregrine)
 1. Local File System
+1. Remote Sling Distributions (Peregrine to remote Peregrine)
 1. Default Distribution
+1. Local, in-Peregrine Copies (deprecated)
 
 **Attention**:
 
@@ -42,7 +42,7 @@ The **name** of the distribution service is the name of a service that implement
 *com.peregrine.replication.Replication* interface. If the name could not be found
 the call ends with an exception.
 
-# Local, intra-Peregrine Copies
+# Local, intra-Peregrine Copies (deprecated)
 
 This distributions allows to copy resources to another folder in the JCR of Peregrine.
 This service copies the resource and any references to other resources (like templates)
@@ -95,20 +95,38 @@ are **author, publish, notshared, shared**.
 
 To set up a configuration do:
 
-1. Create an **Author** and **Publish** instance using **percli** service (*percli server start --author* /
-*percli server start --publish*)
-2. Stop both servers with *percli server stop*
-3. Edit **sling/sling.properties** files
-    1. Add this line to the Author: **sling.run.modes=author,notshared**
-    2. Add this line to the Publish: **sling.run.modes=publish,notshared**
+1. Obtain the peregrine-builder
+   1. Follow instructions from https://github.com/peregrine-cms/peregrine-builder
+1. Create project directories 
+   1. mkdir ~/per-projects
+   1. cd ~/per-projects
+   1. mkdir author
+   1. mkdir publish
+1. Copy Peregrine Builder artifacts into ~/per-projects/author and ~/per-projects/publish
+   1. com.peregrine-cms.sling.launchpad-12-SNAPSHOT-oak_tar_fds_far.far
+   1. org.apache.sling.feature.launcher.jar
+1. Initialize author instance (from author folder)
+   ```
+   java -jar org.apache.sling.feature.launcher.jar -f com.peregrine-cms.sling.launchpad-12-SNAPSHOT-oak_tar_fds_far.far -D sling.runmodes=author,notshared,oak_tar_fds -p sling
+   ``` 
+   Note: `-D sling.runmodes=author,notshared,oak_tar_fds` is only needed the first time
+1. Initialize publish instance (from publish folder)
+   ```
+   java -jar org.apache.sling.feature.launcher.jar -f com.peregrine-cms.sling.launchpad-12-SNAPSHOT-oak_tar_fds_far.far -D sling.runmodes=publish,notshared,oak_tar_fds -D org.osgi.service.http.port=8180 -p sling
+   ```
+1. Install Peregrine CMS
+   1. clone https://github.com/headwirecom/peregrine-cms
+   1. install to the running author instance `mvn clean install -P autoInstallPackage`
+   1. installing to the running publish instance `mvn clean install -P autoInstallPackage -Dsling.port=8180`
+1. Server Side Junit Test  
+   Executing the Sling Junit test (RemoteReplAuthorJTest) from author may be useful for determining whether the setup is correct.
+   ```
+   http://localhost:8080/system/sling/junit/com.peregrine.slingjunit.author.RemoteReplAuthorJTest.html
+   ```
 
-or
+The procedure above will configure Peregrine CMS instance based on the sling runmodes. 
+Additional docs below describe the configurations in more detail in case a manual approach is needed or desired.     
 
-1. Start and Stop two Peregrine Sling instance with the Peregrine Sling JAR file
-2. Edit **sling/sling.properties** files
-    1. Add this line to the Author: **sling.run.modes=author,notshared**
-    2. Add this line to the Publish: **sling.run.modes=publish,notshared**
-3. Restart both Peregrine instances
 
 ### Configure Author Instance
 
@@ -150,7 +168,7 @@ the correct credentials as by default it is set to the default Sling admin passw
 
 On the **Publish** site there is nothing to be done
 
-# Local File System Copies
+# Local File System Copies (Default)
 
 This distribution service will replicate the Peregrine content as files in a given target folder. Regular
 resources (not folders) are exported as **.data.json**, assets as **images** including their renditions

--- a/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
+++ b/platform/base/ui.apps/src/main/content/jcr_root/apps/runmodes/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-peregrine.config
@@ -41,7 +41,6 @@ scripts=[\
     create service user nodejs-service-user
     create service user sitemaps-cache
     create service user distribution-agent-user
-    create service user defaultAgentService
 
 # Set read permission for everyone enabling styled login pages
     set ACL for everyone
@@ -60,11 +59,9 @@ scripts=[\
     end
 
 # Set Permissions for Sling Distribution
-    set ACL for distribution-agent-user, defaultAgentService
+    set ACL for distribution-agent-user
         allow jcr:all on /content
-#        allow jcr:all on /etc/distribution
-#        allow jcr:all on /libs/sling/distribution
-#        allow jcr:all on /var/sling/distribution
+        allow jcr:all on /var/sling/distribution
     end
 
     set ACL for distribution-agent-user

--- a/slingjunit.parent/core/src/main/java/com/peregrine/slingjunit/author/RemoteReplAuthorJTest.java
+++ b/slingjunit.parent/core/src/main/java/com/peregrine/slingjunit/author/RemoteReplAuthorJTest.java
@@ -118,7 +118,7 @@ public class RemoteReplAuthorJTest extends ReplicationTestBase {
 
     @Test
     public void authorDistributionServiceUserAccess() {
-        List<String> allList = Arrays.asList("/var/sling/distribution", "/content", "/etc/distribution","/libs/sling/distribution");
+        List<String> allList = Arrays.asList("/var/sling/distribution", "/content");
         testListGranted(allList, "jcr:all", "distribution-agent-user");
     }
 


### PR DESCRIPTION
Here's a PR to fix ACL's for remote replication for Sling 12 using Distribution 0.4

References

- https://github.com/headwirecom/peregrine-cms/pull/747/files#diff-1df08ff3e39e133596944dc06cc358c91a06495c1107bd888405a3f19821a379
- https://github.com/headwirecom/peregrine-cms/pull/784

I thought in addition it would be good to update the distribution docs with the current practices.
Understanding that these will be changed soon once percli is updated for Sling12
http://localhost:8080/content/docs/pages/public/distribution.html


Thanks for considering this contribution!