### PR TITLE
bump sling junit version to 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <mockito-all.version>1.9.5</mockito-all.version>
         <jmock-junit4.version>2.12.0</jmock-junit4.version>
         <org.apache.sling.commons.testing.version>2.1.0</org.apache.sling.commons.testing.version>
-        <org.apache.sling.junit.core.version>1.1.0</org.apache.sling.junit.core.version>
+        <org.apache.sling.junit.core.version>1.1.2</org.apache.sling.junit.core.version>
         <org.apache.sling.testing.clients.version>2.0.8</org.apache.sling.testing.clients.version>
         <org.apache.sling.testing.rules.version>2.0.0</org.apache.sling.testing.rules.version>
         <org.apache.sling.junit.teleporter.version>1.0.22</org.apache.sling.junit.teleporter.version>


### PR DESCRIPTION
bump sling-junit to 1.1.2 as there are some dependency issues once the launcher is updated to the latest