### PR TITLE
fix: #859 redundant call to endpoint

### DIFF
--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/explorerpreviewcontent/template.vue
@@ -532,15 +532,11 @@ export default {
     activeTab : function(tab) {
       if (tab === 'versions'){
         this.showVersions()
-      } else if (tab === 'references'){
-        this.showReferencedBy()
       }
     },
     currentObject : function(path) {
-      if (this.activeTab === 'versions'){
+      if (this.activeTab === 'versions') {
         this.showVersions()
-      } else if (this.activeTab === 'references'){
-        this.showReferencedBy()
       }
       if (this.stateToolsEdit) {
         this.onEdit()
@@ -781,14 +777,6 @@ export default {
     },
     showVersions() {
       $perAdminApp.getApi().populateVersions(this.currentObject);
-    },
-    showReferencedBy() {
-      this.loading = true
-      $perAdminApp.getApi()
-          .populateReferencedBy(this.currentObject)
-          .then(() => {
-            this.loading = false
-          })
     },
     deleteVersion(me, target) {
       $perAdminApp.stateAction('deleteVersion', { path: target.path, version: target.version.name });


### PR DESCRIPTION
closes #859 

refby used to be loaded async but they are already part of an initial load when clicking a page so this call was redundant