### PR TITLE
Rename variable in login form

### DIFF
--- a/platform/login/src/main/resources/org/apache/sling/auth/form/impl/custom_login.html
+++ b/platform/login/src/main/resources/org/apache/sling/auth/form/impl/custom_login.html
@@ -44,7 +44,7 @@
       <!--suppress CssUnknownTarget -->
       <div class="login-image"></div>
       <div class="login-form-wrapper">
-         <form id="loginform" method="POST" action="${requestContextPath}/j_security_check"
+         <form id="loginform" method="POST" action="${contextPath}/j_security_check"
                enctype="multipart/form-data" accept-charset="UTF-8">
 
             <input type="hidden" name="_charset_" value="UTF-8"/>


### PR DESCRIPTION
Aligns the login form with https://github.com/apache/sling-org-apache-sling-auth-form/blob/master/src/main/resources/org/apache/sling/auth/form/impl/login.html

At runtine this changes the `form` element in the browser from, e.g.,

`<form id="loginform" method="POST" action="/system/console/bundles/j_security_check"
enctype="multipart/form-data" accept-charset="UTF-8">`

to 

`<form id="loginform" method="POST" action="/j_security_check"
enctype="multipart/form-data" accept-charset="UTF-8">`

Fixes #887.