### PR TITLE
per:Asset should inherit form nt:file

### DIFF
--- a/platform/base/core/src/main/resources/SLING-INF/nodetypes/asset.cnd
+++ b/platform/base/core/src/main/resources/SLING-INF/nodetypes/asset.cnd
@@ -25,7 +25,7 @@
 <'per'='http://www.peregrine-cms.com/jcr/cms/1.0'>
 <'sling'='http://sling.apache.org/jcr/sling/1.0'>
 
-[per:Asset] > nt:hierarchyNode, mix:created, mix:lastModified, sling:Resource
+[per:Asset] > nt:hierarchyNode, mix:created, mix:lastModified, sling:Resource, nt:file
   primaryitem jcr:content
   + jcr:content (per:AssetContent) = per:AssetContent
   + * (nt:base) = nt:base version


### PR DESCRIPTION
The per:Asset in Peregrine is intended to work with binary files such as images. As such they should inherit from nt:file, and then a per:Asset resource can be adapted to an Inputstream. This is necessary to make use of org.apache.sling.thumbnails