### PR TITLE
Use a multistage Docker build for leaner images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:latest
+FROM adoptopenjdk/openjdk11:latest AS builder
 
 WORKDIR /app
 
@@ -7,40 +7,42 @@ RUN apt update -q \
     && apt install -q -y --no-install-recommends \
         curl \
         jq \
-        libvips libvips-tools \
-        tar \
-        xz-utils
-
-ENV PATH "/usr/local/lib/nodejs/node-v10.16.0-linux-x64/bin:$PATH"
-
-
-# Start - Use repository/package pinning to upgrade libvips from version 8.4 to 8.6
-COPY overlay/etc/apt/preferences.d/* /etc/apt/preferences.d/
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ focal main restricted" >> /etc/apt/sources.list \
-    && echo "deb http://archive.ubuntu.com/ubuntu/ focal universe" >> /etc/apt/sources.list \
-    && apt update \
-    && apt --only-upgrade install -y libvips libvips-tools
-# End 
-
-COPY files/node-v10.16.0-linux-x64.tar.xz /app/binaries/node-v10.16.0-linux-x64.tar.xz
-
-RUN mkdir -p /usr/local/lib/nodejs \
-    && tar -xf /app/binaries/node-v10.16.0-linux-x64.tar.xz -C /usr/local/lib/nodejs \
-    && echo $PATH \
-    && echo node: $(node -v) \
-    && echo npm: $(npm -v) \
-    && echo npx: $(npx -v) \
-    && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/* && rm -rf /etc/apt/sources.list.d/temp.list;
-
-ARG runmode=none
-ENV APP_VERSION 2.0.0
-ENV RUNMODE=${runmode}
+        nodejs \
+        npm \
+    && apt clean -q -y \
+    && apt autoremove --purge -q -y \
+    && echo node: $(node --version) \
+    && echo npm: $(npm --version) \
+    && echo npx: $(npx --version)
 
 COPY files/* /app/binaries/
 COPY scripts/*.sh /app/scripts/
 
+ARG runmode=none
+ENV RUNMODE=${runmode}
+
 RUN scripts/install-sling.sh
 RUN scripts/install-peregrine.sh ${RUNMODE}
+
+
+
+FROM adoptopenjdk/openjdk11:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/scripts ./scripts
+COPY --from=builder /app/sling ./sling
+
+RUN apt update -q \
+    && apt install -q -y --no-install-recommends \
+        jq \
+        curl \
+        libvips-tools \
+    && apt clean -q -y \
+    && apt autoremove --purge -q -y
+
+ARG runmode=none
+ENV RUNMODE=${runmode}
 
 ENTRYPOINT /app/scripts/start.sh ${RUNMODE} && tail -qF /app/sling/logs/error.log
 

--- a/docker/builddocker.sh
+++ b/docker/builddocker.sh
@@ -5,8 +5,6 @@
 
 . env.sh
 
-./fetchfiles.sh
-
 export RUNMODE=$1
 export DOCKER_IMAGE_WITH_TYPE=${DOCKER_IMAGE}-$2
 if [ -z "$1" ]

--- a/docker/fetchfiles.sh
+++ b/docker/fetchfiles.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-NODE_VERSION=v10.16.0
-NODE_TARBALL=node-${NODE_VERSION}-linux-x64.tar.xz
-NODE_URL=https://nodejs.org/dist/${NODE_VERSION}/${NODE_TARBALL}
-
-if [ ! -e files/${NODE_TARBALL} ]; then
-  curl -L ${NODE_URL} -o files/${NODE_TARBALL}
-fi 

--- a/docker/scripts/install-peregrine.sh
+++ b/docker/scripts/install-peregrine.sh
@@ -29,23 +29,20 @@ for pkg in "${PKG_ORDER[@]}"
 do
   echo "Installing package '${pkg}' in defined order..."
   slingpackager -v upload --install ${PACKAGE_DIR}/$pkg
+  sleep 1
 done
+sleep 4
 
 # Wait for Sling to be fully ready again
 # added an extra sleep to make sure the last package install is completed (sling jobs may take a bit to run)
-sleep 5     
-STATUS=$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)
-if [ "$STATUS" != "[0,0]" ]; then
-  while [ "$STATUS" != "[0,0]" ]
-  do    
-    echo "Sling still starting. Waiting for all bundles to be ready.."
-    sleep 5
-    STATUS=$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)
-  done
-fi
+while [ "$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)" != "[0,0]" ]
+do
+  echo "Sling still starting. Waiting for all bundles to be ready.."
+  sleep 5
+done
 
 #echo "Stopping Peregrine..."
-#kill `ps -ef | grep org.apache.sling.feature.launcher.jar | grep -v grep | awk '{print $2}'`
+kill `ps -ef | grep org.apache.sling.feature.launcher.jar | grep -v grep | awk '{print $2}'`
 
 #echo "Starting Sling for the second time..."
 #/app/scripts/start.sh

--- a/docker/scripts/start.sh
+++ b/docker/scripts/start.sh
@@ -9,13 +9,8 @@ cd /app/sling && java -jar /app/sling/org.apache.sling.feature.launcher.jar \
     -c /app/sling/launcher/cache &
 
 # Wait for Sling to fully start up
-sleep 5
-STATUS=$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)
-if [ "$STATUS" != "[0,0]" ]; then
-  while [ "$STATUS" != "[0,0]" ]
-  do    
-    echo "Sling still starting. Waiting for all bundles to be ready.."
-    sleep 5
-    STATUS=$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)
-  done
-fi
+while [ "$(curl -u admin:admin -s --fail  http://localhost:8080/system/console/bundles.json | jq '.s[3:5]' -c)" != "[0,0]" ]
+do
+  echo "Sling still starting. Waiting for all bundles to be ready.."
+  sleep 2
+done


### PR DESCRIPTION
Refreshed code a bit (resulting from new version of Ubuntu underlying the openjdk image) + used a two-stage build for our docker images. Saves about 200MB on the runnable image.