### PR TITLE
Graphql module fails as slingfeature 

### DIFF
--- a/platform/graphql/ui.apps/pom.xml
+++ b/platform/graphql/ui.apps/pom.xml
@@ -158,11 +158,13 @@
                     </execution>
                 </executions>
             </plugin>
+            
             <plugin>
-                <groupId>io.wcm.maven.plugins</groupId>
-                <artifactId>wcmio-content-package-maven-plugin</artifactId>
+                <groupId> org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
+                    <packageType>mixed</packageType>
                     <!--<serviceURL>http://${sling.host}:${sling.port}/bin/cpm/package.service.html</serviceURL>-->
                     <userId>${sling.user}</userId>
                     <password>${sling.password}</password>

--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                  <groupId>org.apache.jackrabbit</groupId>
+                  <artifactId>filevault-package-maven-plugin</artifactId>
+                  <version>1.3.6</version>
+                </plugin>
+
+                <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>maven-sling-plugin</artifactId>
                     <version>${org.apache.sling.commons.testing.version}</version>


### PR DESCRIPTION
Hi,

I'm currently playing around building my own feature-model with Peregrine on top.

Had a problem in platform/graphql/ui.apps that wasn't starting.

With my new approach (starting from sling-archetype instead of forking the sling-starter) it's already predicting that on build-time:

[ERROR] Failed to execute goal org.apache.sling:slingfeature-maven-plugin:1.8.2:analyse-features (prepare-features) on project launcher: Exception during analysing feature org.motorbrot:launcher:slingosgifeature:app:1.0-SNAPSHOT : graphql-java-15.0.jar has no maven coordinates!

I was able to fix that by replacing the wcmio-content-package-maven-plugin by jackrabbit's filevault-package-maven-plugin.
So I feel obliged to contribute back to this amazing but underappreciated project.

Change is only on the problematic graphql module.
It's only for the part of building the content-packages, wcm.io one still can be used for up/downloading content. [1]

I was starting to change everything, but that would be a lot of changes. Maybe I can pick this up later. [2]
It's not necessary to start Peregrine via slingfeature-maven-plugin.


[1] https://wcm-io.atlassian.net/wiki/spaces/WCMIO/pages/91586585/Migrate+content+package+projects+from+wcmio-content-package-maven-plugin+to+Jackrabbit+filevault-package-maven-plugin

[2] https://wcm-io.atlassian.net/wiki/spaces/WCMIO/pages/1353056261/How+to+make+your+content+packages+comply+with+Jackrabbit+FileVault+Validation